### PR TITLE
Track down and fix Pydantic serialization warnings.

### DIFF
--- a/judgeval/run_evaluation.py
+++ b/judgeval/run_evaluation.py
@@ -36,7 +36,7 @@ def execute_api_eval(evaluation_run: EvaluationRun) -> List[Dict]:
     
     try:
         # submit API request to execute evals
-        response = requests.post(JUDGMENT_EVAL_API_URL, json=evaluation_run.model_dump())
+        response = requests.post(JUDGMENT_EVAL_API_URL, json=evaluation_run.model_dump(warnings='none'))
         response_data = response.json()
     except Exception as e:
         details = response.json().get("detail", "No details provided")

--- a/judgeval/scorers/base_scorer.py
+++ b/judgeval/scorers/base_scorer.py
@@ -15,7 +15,7 @@ class JudgmentScorer(BaseModel):
     Class for ready-made, "out-of-the-box" scorer that uses Judgment evaluators to score `Example`s.
 
     Args:
-        score_type (JudgmentMetric): The Judgment metric to use for scoring `Example`s
+        score_type (APIScorer): The Judgment metric to use for scoring `Example`s
     """
     threshold: float
     score_type: APIScorer


### PR DESCRIPTION
Main idea behind this Pydantic serialization warning was when we were converting the `EvaluationRun` to a JSON (to send as an API request to Judgment backend server for running `APIScorer`'s), it converted two things incorrectly:

1. The `APIScorer` Enums were being implicitly converted to strings (`APIScorer.FAITHFULNESS` -> `"faithfulness"`). This needs to happen, as JSON can't support `Enums`. Additionally, our backend server is expecting strings for `Scorer`'s model names.
3. The `EvaluationResult.example_id` was being implicitly converted to an integer.