### PR TITLE
Bugfix client.assert_test() function: fix imports

### DIFF
--- a/judgeval/judgment_client.py
+++ b/judgeval/judgment_client.py
@@ -7,10 +7,21 @@ import requests
 
 from judgeval.constants import ROOT_API
 from judgeval.data.datasets import EvalDataset
-from judgeval.data import ScoringResult, Example
-from judgeval.scorers import APIJudgmentScorer, JudgevalScorer, ClassifierScorer, ScorerWrapper
+from judgeval.data import (
+    ScoringResult, 
+    Example
+)
+from judgeval.scorers import (
+    APIJudgmentScorer, 
+    JudgevalScorer, 
+    ClassifierScorer, 
+    ScorerWrapper
+)
 from judgeval.evaluation_run import EvaluationRun
-from judgeval.run_evaluation import run_eval
+from judgeval.run_evaluation import (
+    run_eval, 
+    assert_test
+)
 from judgeval.judges import JudgevalJudge
 from judgeval.constants import JUDGMENT_EVAL_FETCH_API_URL
 from judgeval.common.exceptions import JudgmentAPIError
@@ -258,8 +269,8 @@ class JudgmentClient:
     def assert_test(
         self, 
         examples: List[Example],
-        scorers: List[Union[JudgmentScorer, CustomScorer]],
-        model: Union[str, List[str], judgevalJudge],
+        scorers: List[Union[JudgevalScorer, APIJudgmentScorer]],
+        model: Union[str, List[str], JudgevalJudge],
         aggregator: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
         log_results: bool = False,


### PR DESCRIPTION
The `client.assert_test()` function didn't work because the imports were stale. There were issues with the code being outdated once the new client/scorers PR was merged.

This updates the imports and makes the class method work now