### PR TITLE
New Example ID

### DIFF
--- a/src/e2etests/judgment_client_test.py
+++ b/src/e2etests/judgment_client_test.py
@@ -197,7 +197,6 @@ class TestAdvancedFeatures:
             input="What if these shoes don't fit?",
             actual_output='{"tool": "authentication"}',
             retrieval_context=["All customers are eligible for a 30 day full refund at no extra cost."],
-            trace_id="2231abe3-e7e0-4909-8ab7-b4ab60b645c6"
         )
 
         example2 = Example(
@@ -239,7 +238,6 @@ class TestAdvancedFeatures:
             input="What if these shoes don't fit?",
             actual_output="We offer a 30-day full refund at no extra cost.",
             retrieval_context=["All customers are eligible for a 30 day full refund at no extra cost."],
-            trace_id="2231abe3-e7e0-4909-8ab7-b4ab60b645c6"
         )
         
         scorer = FaithfulnessScorer(threshold=0.5)

--- a/src/judgeval/data/datasets/dataset.py
+++ b/src/judgeval/data/datasets/dataset.py
@@ -162,7 +162,8 @@ class EvalDataset:
                 "additional_metadata": ast.literal_eval(row["additional_metadata"]) if pd.notna(row["additional_metadata"]) else dict(),
                 "tools_called": row["tools_called"].split(";") if pd.notna(row["tools_called"]) else [],
                 "expected_tools": row["expected_tools"].split(";") if pd.notna(row["expected_tools"]) else [],
-                "trace_id": row["trace_id"] if pd.notna(row["trace_id"]) else None
+                "trace_id": row["trace_id"] if pd.notna(row["trace_id"]) else None,
+                "example_id": str(row["example_id"]) if pd.notna(row["example_id"]) else None
             }
             if row["example"]:
                 data["name"] = row["name"] if pd.notna(row["name"]) else None

--- a/src/judgeval/data/example.py
+++ b/src/judgeval/data/example.py
@@ -3,10 +3,11 @@ Classes for representing examples in a dataset.
 """
 
 
-from typing import TypeVar, Optional, Any, Dict, List
-from pydantic import BaseModel
+from typing import TypeVar, Optional, Any, Dict, List, UUID
+from pydantic import BaseModel, Field
 from enum import Enum
 from datetime import datetime
+from uuid import uuid4
 
 
 Input = TypeVar('Input')
@@ -33,11 +34,14 @@ class Example(BaseModel):
     tools_called: Optional[List[str]] = None
     expected_tools: Optional[List[str]] = None
     name: Optional[str] = None
-    example_id: Optional[str] = None
+    example_id: UUID = Field(default_factory=uuid4)
+    example_index: Optional[int] = None
     timestamp: Optional[str] = None
     trace_id: Optional[str] = None
 
     def __init__(self, **data):
+        if 'example_id' not in data:
+            data['example_id'] = uuid4()
         super().__init__(**data)
         # Set timestamp if not provided
         if self.timestamp is None:
@@ -54,7 +58,8 @@ class Example(BaseModel):
             "tools_called": self.tools_called,
             "expected_tools": self.expected_tools,
             "name": self.name,
-            "example_id": self.example_id,
+            "example_id": str(self.example_id),
+            "example_index": self.example_index,
             "timestamp": self.timestamp,
             "trace_id": self.trace_id
         }
@@ -71,6 +76,7 @@ class Example(BaseModel):
             f"expected_tools={self.expected_tools}, "
             f"name={self.name}, "
             f"example_id={self.example_id}, "
+            f"example_index={self.example_index}, "
             f"timestamp={self.timestamp}, "
             f"trace_id={self.trace_id})"
         )

--- a/src/judgeval/data/example.py
+++ b/src/judgeval/data/example.py
@@ -41,12 +41,12 @@ class Example(BaseModel):
     trace_id: Optional[str] = None
 
     def __init__(self, **data):
-        super().__init__(**data)
         if 'example_id' not in data:
             data['example_id'] = str(uuid4())
         # Set timestamp if not provided
         if 'timestamp' not in data:
             data['timestamp'] = datetime.now().strftime("%Y%m%d_%H%M%S")
+        super().__init__(**data)
 
 
     def to_dict(self):

--- a/src/judgeval/data/example.py
+++ b/src/judgeval/data/example.py
@@ -3,11 +3,11 @@ Classes for representing examples in a dataset.
 """
 
 
-from typing import TypeVar, Optional, Any, Dict, List, UUID
+from typing import TypeVar, Optional, Any, Dict, List
+from uuid import uuid4
 from pydantic import BaseModel, Field
 from enum import Enum
 from datetime import datetime
-from uuid import uuid4
 
 
 Input = TypeVar('Input')
@@ -34,14 +34,14 @@ class Example(BaseModel):
     tools_called: Optional[List[str]] = None
     expected_tools: Optional[List[str]] = None
     name: Optional[str] = None
-    example_id: UUID = Field(default_factory=uuid4)
+    example_id: str = Field(default_factory=lambda: str(uuid4()))
     example_index: Optional[int] = None
     timestamp: Optional[str] = None
     trace_id: Optional[str] = None
 
     def __init__(self, **data):
         if 'example_id' not in data:
-            data['example_id'] = uuid4()
+            data['example_id'] = str(uuid4())
         super().__init__(**data)
         # Set timestamp if not provided
         if self.timestamp is None:
@@ -58,7 +58,7 @@ class Example(BaseModel):
             "tools_called": self.tools_called,
             "expected_tools": self.expected_tools,
             "name": self.name,
-            "example_id": str(self.example_id),
+            "example_id": self.example_id,
             "example_index": self.example_index,
             "timestamp": self.timestamp,
             "trace_id": self.trace_id

--- a/src/judgeval/data/example.py
+++ b/src/judgeval/data/example.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 from pydantic import BaseModel, Field
 from enum import Enum
 from datetime import datetime
+import time
 
 
 Input = TypeVar('Input')
@@ -40,12 +41,13 @@ class Example(BaseModel):
     trace_id: Optional[str] = None
 
     def __init__(self, **data):
+        super().__init__(**data)
         if 'example_id' not in data:
             data['example_id'] = str(uuid4())
-        super().__init__(**data)
         # Set timestamp if not provided
-        if self.timestamp is None:
-            self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        if 'timestamp' not in data:
+            data['timestamp'] = datetime.now().strftime("%Y%m%d_%H%M%S")
+
 
     def to_dict(self):
         return {

--- a/src/judgeval/run_evaluation.py
+++ b/src/judgeval/run_evaluation.py
@@ -247,12 +247,10 @@ def run_eval(evaluation_run: EvaluationRun, override: bool = False) -> List[Scor
     # Set example IDs if not already set
     debug("Initializing examples with IDs and timestamps")
     for idx, example in enumerate(evaluation_run.examples):
-        if example.example_id is None:
-            example.example_id = idx
-            debug(f"Set example ID {idx} for input: {example.input[:50]}...")
+        example.example_index = idx  # Set numeric index
         example.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         with example_logging_context(example.timestamp, example.example_id):
-            debug(f"Initialized example {example.example_id}")
+            debug(f"Initialized example {example.example_id} (index: {example.example_index})")
             debug(f"Input: {example.input}")
             debug(f"Actual output: {example.actual_output}")
             if example.expected_output:

--- a/src/tests/data/datasets/sample_data/dataset.csv
+++ b/src/tests/data/datasets/sample_data/dataset.csv
@@ -1,3 +1,3 @@
-input,actual_output,expected_output,context,retrieval_context,additional_metadata,tools_called,expected_tools,name,comments,source_file,example,trace_id
-test input,test output,expected output,context1;context2,retrieval1,{'key': 'value'},tool1,tool1;tool2,test example,,,True,123
-test input,,expected output,context1,retrieval1,{'key': 'value'},tool1,tool1,,test comment,test.py,False,094121
+input,actual_output,expected_output,context,retrieval_context,additional_metadata,tools_called,expected_tools,name,comments,source_file,example,trace_id,example_id
+test input,test output,expected output,context1;context2,retrieval1,{'key': 'value'},tool1,tool1;tool2,test example,,,True,123,12345
+test input,,expected output,context1,retrieval1,{'key': 'value'},tool1,tool1,,test comment,test.py,False,094121,12345

--- a/src/tests/data/datasets/sample_data/dataset.json
+++ b/src/tests/data/datasets/sample_data/dataset.json
@@ -47,7 +47,7 @@
                 "tool2"
             ],
             "name": "test example",
-            "example_id": null,
+            "example_id": "12345",
             "timestamp": "20241230_160117",
             "trace_id": "123"
         }

--- a/src/tests/data/datasets/test_dataset.py
+++ b/src/tests/data/datasets/test_dataset.py
@@ -134,7 +134,8 @@ def test_add_from_csv(mock_read_csv, dataset):
         'comments': [None, 'comment2'],
         'source_file': [None, 'file2'],
         'example': [True, False],
-        'trace_id': [None, '123']
+        'trace_id': [None, '123'],
+        'example_id': ['12345', '12345']
     })
     mock_read_csv.return_value = mock_df
 
@@ -242,7 +243,8 @@ def test_load_from_csv():
         tools_called=["tool1"],
         expected_tools=["tool1", "tool2"],
         name="test example",
-        trace_id="123"
+        trace_id="123",
+        example_id="12345"
     )
 
     gt1 = GroundTruthExample(


### PR DESCRIPTION
Added new example_id associated with the evaluations. New example ID is UUID string.

Refactor old example_id into example_index (better suited with the use case)

Example of new example object:
[
        "examples": [
          {
            "name": null,
            "input": "What if these shoes don't fit?",
            "context": null,
            "trace_id": "eb1aba06-b71c-4ec9-98a2-11633f02337d",
            "timestamp": "20250225_145154",
            "example_id": "8602e43e-5f4d-4788-afed-224d4d58cef8",
            "tools_called": null,
            "actual_output": "We offer a 30-day full refund at no extra cost.",
            "example_index": null,
            "expected_tools": [
              "refund"
            ],
            "expected_output": "We offer a 30-day full refund at no extra cost.",
            "retrieval_context": [
              "All customers are eligible for a 30 day full refund at no extra cost."
            ],
            "additional_metadata": null
          }
       ]
 ]
  