### PR TITLE
Refactor Tracer

### DIFF
--- a/src/demo/cookbooks/new_bot/basic_bot.py
+++ b/src/demo/cookbooks/new_bot/basic_bot.py
@@ -1,0 +1,106 @@
+import os
+import asyncio
+from typing import Dict, List
+from openai import OpenAI
+from uuid import uuid4
+from dotenv import load_dotenv
+
+from judgeval.tracer import Tracer, wrap
+from judgeval.scorers import AnswerRelevancyScorer, FaithfulnessScorer
+
+# Initialize clients
+load_dotenv()
+judgment = Tracer(api_key=os.getenv("JUDGMENT_API_KEY"), project_name="restaurant_bot")
+client = wrap(OpenAI())
+
+@judgment.observe(span_type="Research")
+async def search_restaurants(cuisine: str, location: str = "nearby") -> List[Dict]:
+    """Search for restaurants matching the cuisine type."""
+    # Simulate API call to restaurant database
+    prompt = f"Find 3 popular {cuisine} restaurants {location}. Return ONLY a JSON array of objects with 'name', 'rating', and 'price_range' fields. No other text."
+    
+    response = client.chat.completions.create(
+        model="gpt-4",
+        messages=[
+            {"role": "system", "content": """You are a restaurant search expert. 
+             Return ONLY valid JSON arrays containing restaurant objects.
+             Example format: [{"name": "Restaurant Name", "rating": 4.5, "price_range": "$$"}]
+             Do not include any other text or explanations."""},
+            {"role": "user", "content": prompt}
+        ]
+    )
+    
+    try:
+        import json
+        return json.loads(response.choices[0].message.content)
+    except json.JSONDecodeError as e:
+        print(f"Error parsing JSON response: {response.choices[0].message.content}")
+        return [{"name": "Error fetching restaurants", "rating": 0, "price_range": "N/A"}]
+
+@judgment.observe(span_type="Research") 
+async def get_menu_highlights(restaurant_name: str) -> List[str]:
+    """Get popular menu items for a restaurant."""
+    prompt = f"What are 3 must-try dishes at {restaurant_name}?"
+    
+    response = client.chat.completions.create(
+        model="gpt-4",
+        messages=[
+            {"role": "system", "content": "You are a food critic. List only the dish names."},
+            {"role": "user", "content": prompt}
+        ]
+    )
+
+    judgment.get_current_trace().async_evaluate(
+        scorers=[AnswerRelevancyScorer(threshold=0.5)],
+        input=prompt,
+        actual_output=response.choices[0].message.content,
+        model="gpt-4",
+    )
+
+    return response.choices[0].message.content.split("\n")
+
+@judgment.observe(span_type="function")
+async def generate_recommendation(cuisine: str, restaurants: List[Dict], menu_items: Dict[str, List[str]]) -> str:
+    """Generate a natural language recommendation."""
+    context = f"""
+    Cuisine: {cuisine}
+    Restaurants: {restaurants}
+    Popular Items: {menu_items}
+    """
+    
+    response = client.chat.completions.create(
+        model="gpt-4",
+        messages=[
+            {"role": "system", "content": "You are a helpful food recommendation bot. Provide a natural recommendation based on the data."},
+            {"role": "user", "content": context}
+        ]
+    )
+    return response.choices[0].message.content
+
+@judgment.observe(span_type="Research")
+async def get_food_recommendations(cuisine: str) -> str:
+    """Main function to get restaurant recommendations."""
+    # Search for restaurants
+    restaurants = await search_restaurants(cuisine)
+    
+    # Get menu highlights for each restaurant
+    menu_items = {}
+    for restaurant in restaurants:
+        menu_items[restaurant['name']] = await get_menu_highlights(restaurant['name'])
+        
+    # Generate final recommendation
+    recommendation = await generate_recommendation(cuisine, restaurants, menu_items)
+    judgment.get_current_trace().async_evaluate(
+        scorers=[AnswerRelevancyScorer(threshold=0.5), FaithfulnessScorer(threshold=1.0)],
+        input=f"Create a recommendation for a restaurant and dishes based on the desired cuisine: {cuisine}",
+        actual_output=recommendation,
+        retrieval_context=[str(restaurants), str(menu_items)],
+        model="gpt-4",
+    )
+    return recommendation
+
+if __name__ == "__main__":
+    cuisine = input("What kind of food would you like to eat? ")
+    recommendation = asyncio.run(get_food_recommendations(cuisine))
+    print("\nHere are my recommendations:\n")
+    print(recommendation)

--- a/src/demo/cookbooks/openai_travel_agent/tools.py
+++ b/src/demo/cookbooks/openai_travel_agent/tools.py
@@ -5,7 +5,7 @@ from tavily import TavilyClient
 
 from judgeval.common.tracer import Tracer
 
-judgment = Tracer()
+judgment = Tracer(project_name="travel_agent_demo")
 
 @judgment.observe(span_type="search_tool")
 def search_tavily(query):

--- a/src/judgeval/common/tracer.py
+++ b/src/judgeval/common/tracer.py
@@ -596,7 +596,6 @@ class Tracer:
             
             self.api_key: str = api_key
             self.project_name: str = project_name
-            print(f"Initializing Tracer with API key: {api_key} and project name: {project_name}")
             self.client: JudgmentClient = JudgmentClient(judgment_api_key=api_key)
             self.depth: int = 0
             self._current_trace: Optional[str] = None

--- a/src/judgeval/common/tracer.py
+++ b/src/judgeval/common/tracer.py
@@ -588,23 +588,25 @@ class Tracer:
             cls._instance = super(Tracer, cls).__new__(cls)
         return cls._instance
 
-    def __init__(self, api_key: str = os.getenv("JUDGMENT_API_KEY")):
+    def __init__(self, api_key: str = os.getenv("JUDGMENT_API_KEY"), project_name: str = "default_project"):
         if not hasattr(self, 'initialized'):
 
             if not api_key:
                 raise ValueError("Tracer must be configured with a Judgment API key")
             
             self.api_key: str = api_key
+            self.project_name: str = project_name
             self.client: JudgmentClient = JudgmentClient(judgment_api_key=api_key)
             self.depth: int = 0
             self._current_trace: Optional[str] = None
             self.initialized: bool = True
         
     @contextmanager
-    def trace(self, name: str, project_name: str = "default_project", overwrite: bool = False) -> Generator[TraceClient, None, None]:
+    def trace(self, name: str, project_name: str = None, overwrite: bool = False) -> Generator[TraceClient, None, None]:
         """Start a new trace context using a context manager"""
         trace_id = str(uuid.uuid4())
-        trace = TraceClient(self, trace_id, name, project_name=project_name, overwrite=overwrite)
+        project = project_name if project_name is not None else self.project_name
+        trace = TraceClient(self, trace_id, name, project_name=project, overwrite=overwrite)
         prev_trace = self._current_trace
         self._current_trace = trace
         
@@ -623,28 +625,40 @@ class Tracer:
         """
         return self._current_trace    
 
-    def observe(self, func=None, *, name=None, span_type: SpanType = "span"):
+    def observe(self, func=None, *, name=None, span_type: SpanType = "span", project_name: str = None, overwrite: bool = False):
         """
         Decorator to trace function execution with detailed entry/exit information.
         
         Args:
-            func: The function to trace
-            name: Optional custom name for the function
-            span_type: The type of span to use for this observation (default: "span")
+            func: The function to decorate
+            name: Optional custom name for the span (defaults to function name)
+            span_type: Type of span (default "span")
+            project_name: Optional project name override
+            overwrite: Whether to overwrite existing traces
         """
         if func is None:
-            return lambda f: self.observe(f, name=name, span_type=span_type)
+            return lambda f: self.observe(f, name=name, span_type=span_type, project_name=project_name, overwrite=overwrite)
+        
+        # Use provided name or fall back to function name
+        span_name = name or func.__name__
         
         if asyncio.iscoroutinefunction(func):
             @functools.wraps(func)
             async def async_wrapper(*args, **kwargs):
+                # If there's already a trace, use it. Otherwise create a new one
                 if self._current_trace:
-                    span_name = name or func.__name__
-                    
-                    with self._current_trace.span(span_name, span_type=span_type) as span:
-                        # Set the span type
-                        span.span_type = span_type
-                        
+                    trace = self._current_trace
+                else:
+                    trace_id = str(uuid.uuid4())
+                    trace_name = str(uuid.uuid4())
+                    project = project_name if project_name is not None else self.project_name
+                    trace = TraceClient(self, trace_id, trace_name, project_name=project, overwrite=overwrite)
+                    self._current_trace = trace
+                    # Only save empty trace for the root call
+                    trace.save(empty_save=True, overwrite=overwrite)
+
+                try:
+                    with trace.span(span_name, span_type=span_type) as span:
                         # Record inputs
                         span.record_input({
                             'args': list(args),
@@ -658,19 +672,30 @@ class Tracer:
                         span.record_output(result)
                         
                         return result
-                
-                return await func(*args, **kwargs)
+                finally:
+                    # Only save and cleanup if this is the root observe call
+                    if self.depth == 0:
+                        trace.save(empty_save=False, overwrite=overwrite)
+                        self._current_trace = None
+                    
             return async_wrapper
         else:
             @functools.wraps(func)
             def wrapper(*args, **kwargs):
+                # If there's already a trace, use it. Otherwise create a new one
                 if self._current_trace:
-                    span_name = name or func.__name__
-                    
-                    with self._current_trace.span(span_name, span_type=span_type) as span:
-                        # Set the span type
-                        span.span_type = span_type
-                        
+                    trace = self._current_trace
+                else:
+                    trace_id = str(uuid.uuid4())
+                    trace_name = str(uuid.uuid4())
+                    project = project_name if project_name is not None else self.project_name
+                    trace = TraceClient(self, trace_id, trace_name, project_name=project, overwrite=overwrite)
+                    self._current_trace = trace
+                    # Only save empty trace for the root call
+                    trace.save(empty_save=True, overwrite=overwrite)
+                
+                try:
+                    with trace.span(span_name, span_type=span_type) as span:
                         # Record inputs
                         span.record_input({
                             'args': list(args),
@@ -684,8 +709,12 @@ class Tracer:
                         span.record_output(result)
                         
                         return result
-                
-                return func(*args, **kwargs)
+                finally:
+                    # Only save and cleanup if this is the root observe call
+                    if self.depth == 0:
+                        trace.save(empty_save=False, overwrite=overwrite)
+                        self._current_trace = None
+                    
             return wrapper
 
 def wrap(client: Any) -> Any:


### PR DESCRIPTION
This PR updates the tracer syntax to be more uniform. 

1. Before, we had to write both `@observe` statements as well as the context manager `with judgment.trace(...) as trace`. Logically, this was a bit confusing and unnecessary. 

Now, we can just label every function that we want to trace with `@judgment.observe`! Easy as pie.

Before (main func):
```
async def get_food_recommendations(cuisine: str) -> str:
    """Main function to get restaurant recommendations."""
    # Search for restaurants
    with judgment.trace(name="...", project_name="...", overwrite=True):
      restaurants = await search_restaurants(cuisine)
      
      # Get menu highlights for each restaurant
      menu_items = {}
      for restaurant in restaurants:
          menu_items[restaurant['name']] = await get_menu_highlights(restaurant['name'])
          
      # Generate final recommendation
      recommendation = await generate_recommendation(cuisine, restaurants, menu_items)
```

After (main func):
```
@judgment.observe(span_type="Main Func")
async def get_food_recommendations(cuisine: str) -> str:
    """Main function to get restaurant recommendations."""
    # Search for restaurants
    restaurants = await search_restaurants(cuisine)
    
    # Get menu highlights for each restaurant
    menu_items = {}
    for restaurant in restaurants:
        menu_items[restaurant['name']] = await get_menu_highlights(restaurant['name'])
        
    # Generate final recommendation
    recommendation = await generate_recommendation(cuisine, restaurants, menu_items)
```

2. Project management in tracer init

We now define the project that the tracer routes to in the init:

`judgment = Tracer(project_name="my_project")`

and now, the trace names are no longer defined by the `name` field in the context manager; instead, it is simply a UUID4.
