### PR TITLE
Type warning

### DIFF
--- a/src/demo/cookbooks/notification_demo/notification_bot.py
+++ b/src/demo/cookbooks/notification_demo/notification_bot.py
@@ -1,0 +1,155 @@
+import os
+import asyncio
+from typing import Dict, List, Optional
+from openai import OpenAI
+from uuid import uuid4
+from dotenv import load_dotenv
+
+from judgeval.common.tracer import Tracer, wrap
+from judgeval.scorers import AnswerRelevancyScorer, FaithfulnessScorer, AnswerCorrectnessScorer
+from judgeval.rules import Rule, Condition, Operator, NotificationConfig
+
+# Initialize environment variables and clients
+load_dotenv()
+
+# Initialize the rules with notification config
+# This demo only supports slack and email notification methods
+notification_config = NotificationConfig(
+    enabled=True,
+    communication_methods=[ "email"],  # Only using slack and email
+    message_template="Rule '{rule_name}' was triggered with score {score}",
+    email_addresses=["minh@judgmentlabs.ai"],  # Replace with your email
+    slack_channels=["general"],  # Replace with your slack channel
+    send_at=None  # Send immediately
+)
+
+# Create rules with the notification config
+rules = [
+    Rule(
+        name="All Conditions Check",
+        description="Check if all conditions are met",
+        conditions=[
+            Condition(metric=FaithfulnessScorer(threshold=0.7), operator=Operator.GTE, threshold=0.7),
+            Condition(metric=AnswerRelevancyScorer(threshold=0.8), operator=Operator.GTE, threshold=0.8),
+            Condition(metric=AnswerCorrectnessScorer(threshold=0.9), operator=Operator.GTE, threshold=0.9)
+        ],
+        combine_type="all",  # Require all conditions to trigger
+        notification=notification_config
+    ),
+    Rule(
+        name="Any Condition Check",
+        description="Check if any condition is met",
+        conditions=[
+            Condition(metric=FaithfulnessScorer(threshold=0.7), operator=Operator.GTE, threshold=0.7),
+            Condition(metric=AnswerRelevancyScorer(threshold=0.8), operator=Operator.GTE, threshold=0.8),
+            Condition(metric=AnswerCorrectnessScorer(threshold=0.9), operator=Operator.GTE, threshold=0.9)
+        ],
+        combine_type="any",  # Require any condition to trigger
+        notification=notification_config
+    )
+]
+
+# Initialize tracer with rules for notifications
+judgment = Tracer(
+    api_key=os.getenv("JUDGMENT_API_KEY"), 
+    project_name="notification_demo", 
+    rules=rules
+)
+
+# Wrap OpenAI client for tracing
+client = wrap(OpenAI())
+
+judgment = Tracer(api_key=os.getenv("JUDGMENT_API_KEY"), project_name="restaurant_bot", rules=rules)
+client = wrap(OpenAI())
+
+@judgment.observe(span_type="Research")
+async def search_restaurants(cuisine: str, location: str = "nearby") -> List[Dict]:
+    """Search for restaurants matching the cuisine type."""
+    # Simulate API call to restaurant database
+    prompt = f"Find 3 popular {cuisine} restaurants {location}. Return ONLY a JSON array of objects with 'name', 'rating', and 'price_range' fields. No other text."
+    
+    response = client.chat.completions.create(
+        model="gpt-4",
+        messages=[
+            {"role": "system", "content": """You are a restaurant search expert. 
+             Return ONLY valid JSON arrays containing restaurant objects.
+             Example format: [{"name": "Restaurant Name", "rating": 4.5, "price_range": "$$"}]
+             Do not include any other text or explanations."""},
+            {"role": "user", "content": prompt}
+        ]
+    )
+    
+    try:
+        import json
+        return json.loads(response.choices[0].message.content)
+    except json.JSONDecodeError as e:
+        print(f"Error parsing JSON response: {response.choices[0].message.content}")
+        return [{"name": "Error fetching restaurants", "rating": 0, "price_range": "N/A"}]
+
+@judgment.observe(span_type="Research") 
+async def get_menu_highlights(restaurant_name: str) -> List[str]:
+    """Get popular menu items for a restaurant."""
+    prompt = f"What are 3 must-try dishes at {restaurant_name}?"
+    
+    response = client.chat.completions.create(
+        model="gpt-4",
+        messages=[
+            {"role": "system", "content": "You are a food critic. List only the dish names."},
+            {"role": "user", "content": prompt}
+        ]
+    )
+
+    judgment.get_current_trace().async_evaluate(
+        scorers=[AnswerRelevancyScorer(threshold=0.5)],
+        input=prompt,
+        actual_output=response.choices[0].message.content,
+        model="gpt-4",
+    )
+
+    return response.choices[0].message.content.split("\n")
+
+@judgment.observe(span_type="function")
+async def generate_recommendation(cuisine: str, restaurants: List[Dict], menu_items: Dict[str, List[str]]) -> str:
+    """Generate a natural language recommendation."""
+    context = f"""
+    Cuisine: {cuisine}
+    Restaurants: {restaurants}
+    Popular Items: {menu_items}
+    """
+    
+    response = client.chat.completions.create(
+        model="gpt-4",
+        messages=[
+            {"role": "system", "content": "You are a helpful food recommendation bot. Provide a natural recommendation based on the data."},
+            {"role": "user", "content": context}
+        ]
+    )
+    return response.choices[0].message.content
+
+@judgment.observe(span_type="Research")
+async def get_food_recommendations(cuisine: str) -> str:
+    """Main function to get restaurant recommendations."""
+    # Search for restaurants
+    restaurants = await search_restaurants(cuisine)
+    
+    # Get menu highlights for each restaurant
+    menu_items = {}
+    for restaurant in restaurants:
+        menu_items[restaurant['name']] = await get_menu_highlights(restaurant['name'])
+        
+    # Generate final recommendation
+    recommendation = await generate_recommendation(cuisine, restaurants, menu_items)
+    judgment.get_current_trace().async_evaluate(
+        scorers=[AnswerRelevancyScorer(threshold=0.5), FaithfulnessScorer(threshold=1.0)],
+        input=f"Create a recommendation for a restaurant and dishes based on the desired cuisine: {cuisine}",
+        actual_output=recommendation,
+        retrieval_context=[str(restaurants), str(menu_items)],
+        model="gpt-4",
+    )
+    return recommendation
+
+if __name__ == "__main__":
+    cuisine = input("What kind of food would you like to eat? ")
+    recommendation = asyncio.run(get_food_recommendations(cuisine))
+    print("\nHere are my recommendations:\n")
+    print(recommendation)

--- a/src/demo/cookbooks/notification_demo/notification_bot.py
+++ b/src/demo/cookbooks/notification_demo/notification_bot.py
@@ -16,10 +16,9 @@ load_dotenv()
 # This demo only supports slack and email notification methods
 notification_config = NotificationConfig(
     enabled=True,
-    communication_methods=[ "email"],  # Only using slack and email
+    communication_methods=["slack", "email"],  # Only using slack and email
     message_template="Rule '{rule_name}' was triggered with score {score}",
     email_addresses=["minh@judgmentlabs.ai"],  # Replace with your email
-    slack_channels=["general"],  # Replace with your slack channel
     send_at=None  # Send immediately
 )
 

--- a/src/demo/cookbooks/rules_alerts/rules_demo.py
+++ b/src/demo/cookbooks/rules_alerts/rules_demo.py
@@ -30,6 +30,7 @@ from judgeval.scorers.judgeval_scorer import JudgevalScorer
 from judgeval.scorers import FaithfulnessScorer, AnswerRelevancyScorer, AnswerCorrectnessScorer
 from judgeval.rules import AlertResult, Condition, Operator, Rule, RulesEngine, AlertStatus
 
+
 # Try to import utilities from judgeval package first, fall back to local helper if needed
 try:
     from judgeval.scorers.utils import scorer_progress_meter, create_verbose_logs
@@ -348,4 +349,5 @@ def main():
 
 
 if __name__ == "__main__":
+
     main() 

--- a/src/e2etests/judgment_client_test.py
+++ b/src/e2etests/judgment_client_test.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 load_dotenv()
 
 # Constants
-SERVER_URL = os.getenv("JUDGMENT_API_URL", "http://localhost:8000")
+SERVER_URL = os.getenv("JUDGMENT_API_URL", "https://127.0.0.1:8000")
 API_KEY = os.getenv("JUDGMENT_API_KEY")
 ORGANIZATION_ID = os.getenv("ORGANIZATION_ID")
 

--- a/src/judgeval/common/tracer.py
+++ b/src/judgeval/common/tracer.py
@@ -664,7 +664,6 @@ class Tracer:
             
             if not organization_id:
                 raise ValueError("Tracer must be configured with an Organization ID")
-            
             self.api_key: str = api_key
             self.project_name: str = project_name
             self.client: JudgmentClient = JudgmentClient(judgment_api_key=api_key)

--- a/src/judgeval/constants.py
+++ b/src/judgeval/constants.py
@@ -31,7 +31,7 @@ class APIScorer(str, Enum):
             if member.value == value.lower():
                 return member
 
-ROOT_API = os.getenv("JUDGMENT_API_URL", "https://api.judgmentlabs.ai")
+ROOT_API = os.getenv("JUDGMENT_API_URL", "https://127.0.0.1:8000")
 # API URLs
 JUDGMENT_EVAL_API_URL = f"{ROOT_API}/evaluate/"
 JUDGMENT_DATASETS_PUSH_API_URL = f"{ROOT_API}/datasets/push/"
@@ -48,7 +48,7 @@ JUDGMENT_TRACES_SAVE_API_URL = f"{ROOT_API}/traces/save/"
 JUDGMENT_TRACES_DELETE_API_URL = f"{ROOT_API}/traces/delete/"
 
 # RabbitMQ
-RABBITMQ_HOST = os.getenv("RABBITMQ_HOST", "rabbitmq-networklb-faa155df16ec9085.elb.us-west-1.amazonaws.com")
+RABBITMQ_HOST = os.getenv("RABBITMQ_HOST", "localhost")
 RABBITMQ_PORT = os.getenv("RABBITMQ_PORT", 5672)
 RABBITMQ_QUEUE = os.getenv("RABBITMQ_QUEUE", "task_queue")
 # Models

--- a/src/judgeval/rules.py
+++ b/src/judgeval/rules.py
@@ -87,22 +87,21 @@ class NotificationConfig(BaseModel):
     Example:
         {
             "enabled": true,
-            "communication_methods": ["slack", "email", "broadcast_slack", "broadcast_email"],
+            "communication_methods": ["email", "broadcast_slack", "broadcast_email"],
             "message_template": "Rule '{rule_name}' was triggered with score {score}",
             "email_addresses": ["user1@example.com", "user2@example.com"],
-            "slack_channels": ["general", "alerts"],
             "send_at": 1632150000  # Unix timestamp (specific date/time)
         }
         
     Communication Methods:
-        - "slack": Send notifications to specified Slack channels
         - "email": Send emails to specified email addresses
+        - "broadcast_slack": Send broadcast notifications to all configured Slack channels
+        - "broadcast_email": Send broadcast emails to all organization emails
     """
     enabled: bool = True
     communication_methods: List[str] = []
     message_template: Optional[str] = None
     email_addresses: Optional[List[str]] = None
-    slack_channels: Optional[List[str]] = None
     send_at: Optional[int] = None  # Unix timestamp for scheduled notifications
     
     def model_dump(self, **kwargs):
@@ -369,7 +368,6 @@ class RulesEngine:
                               communication_methods: List[str] = None, 
                               message_template: str = None,
                               email_addresses: List[str] = None,
-                              slack_channels: List[str] = None,
                               send_at: Optional[int] = None) -> None:
         """
         Configure notification settings for a specific rule.
@@ -380,7 +378,6 @@ class RulesEngine:
             communication_methods: List of notification methods (e.g., ["slack", "email"])
             message_template: Template string for the notification message
             email_addresses: List of email addresses to send notifications to
-            slack_channels: List of Slack channels to send notifications to
             send_at: Optional Unix timestamp for when to send the notification
         """
         if rule_id not in self.rules:
@@ -404,16 +401,12 @@ class RulesEngine:
         if email_addresses is not None:
             rule.notification.email_addresses = email_addresses
             
-        if slack_channels is not None:
-            rule.notification.slack_channels = slack_channels
-            
         if send_at is not None:
             rule.notification.send_at = send_at
     
     def configure_all_notifications(self, enabled: bool = True, 
                                    communication_methods: List[str] = None,
                                    email_addresses: List[str] = None,
-                                   slack_channels: List[str] = None,
                                    send_at: Optional[int] = None) -> None:
         """
         Configure notification settings for all rules.
@@ -422,7 +415,6 @@ class RulesEngine:
             enabled: Whether notifications are enabled
             communication_methods: List of notification methods (e.g., ["slack", "email"])
             email_addresses: List of email addresses to send notifications to
-            slack_channels: List of Slack channels to send notifications to
             send_at: Optional Unix timestamp for when to send the notification
         """
         for rule_id, rule in self.rules.items():
@@ -435,7 +427,6 @@ class RulesEngine:
                 communication_methods=communication_methods,
                 message_template=message_template,
                 email_addresses=email_addresses,
-                slack_channels=slack_channels,
                 send_at=send_at
             )
     

--- a/src/judgeval/rules.py
+++ b/src/judgeval/rules.py
@@ -87,17 +87,33 @@ class NotificationConfig(BaseModel):
     Example:
         {
             "enabled": true,
-            "communication_methods": ["slack", "email"],
+            "communication_methods": ["slack", "email", "broadcast_slack", "broadcast_email"],
             "message_template": "Rule '{rule_name}' was triggered with score {score}",
             "email_addresses": ["user1@example.com", "user2@example.com"],
+            "slack_channels": ["general", "alerts"],
             "send_at": 1632150000  # Unix timestamp (specific date/time)
         }
+        
+    Communication Methods:
+        - "slack": Send notifications to specified Slack channels
+        - "email": Send emails to specified email addresses
     """
     enabled: bool = True
     communication_methods: List[str] = []
     message_template: Optional[str] = None
     email_addresses: Optional[List[str]] = None
+    slack_channels: Optional[List[str]] = None
     send_at: Optional[int] = None  # Unix timestamp for scheduled notifications
+    
+    def model_dump(self, **kwargs):
+        """Convert the NotificationConfig to a dictionary for JSON serialization."""
+        return {
+            "enabled": self.enabled,
+            "communication_methods": self.communication_methods,
+            "message_template": self.message_template,
+            "email_addresses": self.email_addresses,
+            "send_at": self.send_at
+        }
 
 class Rule(BaseModel):
     """
@@ -353,6 +369,7 @@ class RulesEngine:
                               communication_methods: List[str] = None, 
                               message_template: str = None,
                               email_addresses: List[str] = None,
+                              slack_channels: List[str] = None,
                               send_at: Optional[int] = None) -> None:
         """
         Configure notification settings for a specific rule.
@@ -363,6 +380,7 @@ class RulesEngine:
             communication_methods: List of notification methods (e.g., ["slack", "email"])
             message_template: Template string for the notification message
             email_addresses: List of email addresses to send notifications to
+            slack_channels: List of Slack channels to send notifications to
             send_at: Optional Unix timestamp for when to send the notification
         """
         if rule_id not in self.rules:
@@ -386,12 +404,16 @@ class RulesEngine:
         if email_addresses is not None:
             rule.notification.email_addresses = email_addresses
             
+        if slack_channels is not None:
+            rule.notification.slack_channels = slack_channels
+            
         if send_at is not None:
             rule.notification.send_at = send_at
     
     def configure_all_notifications(self, enabled: bool = True, 
                                    communication_methods: List[str] = None,
                                    email_addresses: List[str] = None,
+                                   slack_channels: List[str] = None,
                                    send_at: Optional[int] = None) -> None:
         """
         Configure notification settings for all rules.
@@ -400,6 +422,7 @@ class RulesEngine:
             enabled: Whether notifications are enabled
             communication_methods: List of notification methods (e.g., ["slack", "email"])
             email_addresses: List of email addresses to send notifications to
+            slack_channels: List of Slack channels to send notifications to
             send_at: Optional Unix timestamp for when to send the notification
         """
         for rule_id, rule in self.rules.items():
@@ -412,6 +435,7 @@ class RulesEngine:
                 communication_methods=communication_methods,
                 message_template=message_template,
                 email_addresses=email_addresses,
+                slack_channels=slack_channels,
                 send_at=send_at
             )
     

--- a/src/judgeval/run_evaluation.py
+++ b/src/judgeval/run_evaluation.py
@@ -23,7 +23,6 @@ from judgeval.constants import (
     MAX_CONCURRENT_EVALUATIONS
 )
 from judgeval.common.exceptions import JudgmentAPIError
-from judgeval.evaluation_run import EvaluationRun
 from judgeval.common.logger import (
     enable_logging, 
     debug, 
@@ -31,6 +30,7 @@ from judgeval.common.logger import (
     error, 
     example_logging_context
 )
+from judgeval.evaluation_run import EvaluationRun
 from judgeval.rules import RulesEngine, Rule, AlertResult, AlertStatus
 
 

--- a/src/judgeval/scorers/api_scorer.py
+++ b/src/judgeval/scorers/api_scorer.py
@@ -34,16 +34,16 @@ class APIJudgmentScorer(BaseModel):
     @field_validator('score_type')
     def convert_to_enum_value(cls, v):
         """
-        Validates that the `score_type` is a valid `JudgmentMetric` enum value.
-        Converts string values to `JudgmentMetric` enum values.
+        Validates that the `score_type` is a valid `APIScorer` enum value.
+        Converts string values to `APIScorer` enum values.
         """
         debug(f"Attempting to convert score_type value: {v}")
         if isinstance(v, APIScorer):
-            info(f"Using existing JudgmentMetric: {v.value}")
-            return v.value
+            info(f"Using existing APIScorer: {v}")
+            return v
         elif isinstance(v, str):
-            debug(f"Converting string value to JudgmentMetric enum: {v}")
-            return APIScorer[v.upper()].value
+            debug(f"Converting string value to APIScorer enum: {v}")
+            return APIScorer[v.upper()]
         error(f"Invalid score_type value: {v}")
         raise ValueError(f"Invalid value for score_type: {v}")
     
@@ -58,7 +58,7 @@ class APIJudgmentScorer(BaseModel):
             dict: A dictionary containing the scorer's configuration
         """
         return {
-            "score_type": self.score_type,
+            "score_type": self.score_type.value,  # Convert enum to string for serialization
             "threshold": self.threshold
         }
     

--- a/src/judgeval/utils/alerts.py
+++ b/src/judgeval/utils/alerts.py
@@ -41,3 +41,35 @@ class AlertResult(BaseModel):
     def conditions_results(self) -> List[Dict[str, Any]]:
         """Backwards compatibility property for the conditions_result field"""
         return self.conditions_result
+
+    def model_dump(self, **kwargs):
+        """
+        Convert the AlertResult to a dictionary for JSON serialization.
+        
+        Args:
+            **kwargs: Additional arguments to pass to Pydantic's model_dump
+        
+        Returns:
+            dict: Dictionary representation of the AlertResult
+        """
+        data = super().model_dump(**kwargs) if hasattr(super(), "model_dump") else super().dict(**kwargs)
+        
+        # Handle the NotificationConfig object if it exists
+        if hasattr(self, "notification") and self.notification is not None:
+            if hasattr(self.notification, "model_dump"):
+                data["notification"] = self.notification.model_dump()
+            elif hasattr(self.notification, "dict"):
+                data["notification"] = self.notification.dict()
+            else:
+                # Manually convert the notification to a dictionary
+                notif = self.notification
+                data["notification"] = {
+                    "enabled": notif.enabled,
+                    "communication_methods": notif.communication_methods,
+                    "message_template": notif.message_template,
+                    "email_addresses": notif.email_addresses,
+                    "slack_channels": getattr(notif, "slack_channels", []),
+                    "send_at": notif.send_at
+                }
+        
+        return data


### PR DESCRIPTION
Just fix the:
UserWarning: Pydantic serializer warnings:
  Expected `enum` but got `str` with value `'answer_relevancy'` - serialized value may not be as expected
  Expected `enum` but got `str` with value `'faithfulness'` - serialized value may not be as expected
  Expected `enum` but got `str` with value `'faithfulness'` - serialized value may not be as expected
  Expected `enum` but got `str` with value `'answer_relevancy'` - serialized value may not be as expected
  Expected `enum` but got `str` with value `'answer_correctness'` - serialized value may not be as expected
  Expected `enum` but got `str` with value `'faithfulness'` - serialized value may not be as expected
  Expected `enum` but got `str` with value `'answer_relevancy'` - serialized value may not be as expected
  Expected `enum` but got `str` with value `'answer_correctness'` - serialized value may not be as expected
  
 By changing the validator