### PR TITLE
Type warning fix

### DIFF
--- a/src/e2etests/test_rules_alerts.py
+++ b/src/e2etests/test_rules_alerts.py
@@ -73,7 +73,7 @@ async def evaluate_example(example: Example) -> Dict:
     results = judgment_client.run_evaluation(
         examples=[example],
         scorers=[correctness_scorer, relevancy_scorer, faithfulness_scorer],
-        model="QWEN",
+        model="Qwen/Qwen2.5-72B-Instruct-Turbo",
         log_results=True,
         project_name="rules-test-project",
         eval_run_name=f"rules-test-{uuid4().hex[:8]}",
@@ -251,7 +251,7 @@ async def test_complex_rules():
             results = judgment_client.run_evaluation(
                 examples=[example],
                 scorers=[correctness_scorer, relevancy_scorer, faithfulness_scorer],
-                model="QWEN",
+                model="Qwen/Qwen2.5-72B-Instruct-Turbo",
                 log_results=True,
                 project_name="rules-test-project",
                 eval_run_name=f"complex-rules-test-{uuid4().hex[:8]}",

--- a/src/judgeval/scorers/api_scorer.py
+++ b/src/judgeval/scorers/api_scorer.py
@@ -58,6 +58,6 @@ class APIJudgmentScorer(BaseModel):
             dict: A dictionary containing the scorer's configuration
         """
         return {
-            "score_type": self.score_type.value,  # Convert enum to string for serialization
+            "score_type": str(self.score_type.value),  # Convert enum to string for serialization
             "threshold": self.threshold
         }

--- a/src/judgeval/scorers/api_scorer.py
+++ b/src/judgeval/scorers/api_scorer.py
@@ -34,22 +34,22 @@ class APIJudgmentScorer(BaseModel):
     @field_validator('score_type')
     def convert_to_enum_value(cls, v):
         """
-        Validates that the `score_type` is a valid `JudgmentMetric` enum value.
-        Converts string values to `JudgmentMetric` enum values.
+        Validates that the `score_type` is a valid `APIScorer` enum value.
+        Converts string values to `APIScorer` enum values.
         """
         debug(f"Attempting to convert score_type value: {v}")
         if isinstance(v, APIScorer):
-            info(f"Using existing JudgmentMetric: {v.value}")
-            return v.value
+            info(f"Using existing APIScorer: {v}")
+            return v
         elif isinstance(v, str):
-            debug(f"Converting string value to JudgmentMetric enum: {v}")
-            return APIScorer[v.upper()].value
+            debug(f"Converting string value to APIScorer enum: {v}")
+            return APIScorer[v.upper()]
         error(f"Invalid score_type value: {v}")
         raise ValueError(f"Invalid value for score_type: {v}")
-    
+
     def __str__(self):
-        return f"JudgmentScorer(score_type={self.score_type}, threshold={self.threshold})"
-    
+        return f"JudgmentScorer(score_type={self.score_type.value}, threshold={self.threshold})"
+
     def to_dict(self) -> dict:
         """
         Converts the scorer configuration to a dictionary format.
@@ -58,7 +58,6 @@ class APIJudgmentScorer(BaseModel):
             dict: A dictionary containing the scorer's configuration
         """
         return {
-            "score_type": self.score_type,
+            "score_type": self.score_type.value,  # Convert enum to string for serialization
             "threshold": self.threshold
         }
-    

--- a/src/judgeval/scorers/base_scorer.py
+++ b/src/judgeval/scorers/base_scorer.py
@@ -48,5 +48,5 @@ class APIJudgmentScorer(BaseModel):
         raise ValueError(f"Invalid value for score_type: {v}")
     
     def __str__(self):
-        return f"JudgmentScorer(score_type={self.score_type}, threshold={self.threshold})"
+        return f"JudgmentScorer(score_type={self.score_type.value}, threshold={self.threshold})"
     


### PR DESCRIPTION
Just fix the:
UserWarning: Pydantic serializer warnings:
Expected enum but got str with value 'answer_relevancy' - serialized value may not be as expected
Expected enum but got str with value 'faithfulness' - serialized value may not be as expected
Expected enum but got str with value 'faithfulness' - serialized value may not be as expected
Expected enum but got str with value 'answer_relevancy' - serialized value may not be as expected
Expected enum but got str with value 'answer_correctness' - serialized value may not be as expected
Expected enum but got str with value 'faithfulness' - serialized value may not be as expected
Expected enum but got str with value 'answer_relevancy' - serialized value may not be as expected
Expected enum but got str with value 'answer_correctness' - serialized value may not be as expected

By changing the validator