### PR TITLE
Add langchain dependencies from integration to pypoject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ dependencies = [
     "anthropic",
     "nest-asyncio",
     "pika",
+    "openpyxl",
+    "langchain",
+    "langchain-huggingface",
+    "langchain-openai",
+    "langchain-anthropic",
+    "langchain-core",
 ]
 
 [project.optional-dependencies]
@@ -35,8 +41,6 @@ dev = [
     "pytest>=8.3.4",
     "pytest-asyncio>=0.25.0",
     "pytest-mock>=3.14.0",
-    "langfuse==2.50.3",
-    "patronus",
     "tavily-python"
 ]
 


### PR DESCRIPTION
previously, people had a bit of trouble with importing from `judgeval` since we upgraded the package to require the dependencies from our `langgraph` integration. Now, those are added to the package dependencies by default