### PR TITLE
Made sure proper UTC time passed to Supabase

### DIFF
--- a/src/judgeval/common/tracer.py
+++ b/src/judgeval/common/tracer.py
@@ -636,7 +636,7 @@ class TraceClient:
             "trace_id": self.trace_id,
             "name": self.name,
             "project_name": self.project_name,
-            "created_at": datetime.fromtimestamp(self.start_time).isoformat(),
+            "created_at": datetime.utcfromtimestamp(self.start_time).isoformat(),
             "duration": total_duration,
             "token_counts": {
                 "prompt_tokens": total_prompt_tokens,


### PR DESCRIPTION
Fixed an issue where the times being passed to Supabase were not correct. They were stored as the local time of the user but as UTC, which is incorrect. Now they are the proper UTC time, and this allows the times to be displayed properly in the website. 