### PR TITLE
Add ability to have Tracer save traces to S3 bucket

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -26,6 +26,7 @@ langchain-core = "*"
 langchain-community = "*"
 langgraph = "*"
 google-genai = "*"
+boto3 = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "34dbe83e16706cafb022557b3cf486780a36319b97985c269ad35a8f1666e4b8"
+            "sha256": "3e328be66972124856e344a314418bb2bb2ceb530d7a7332ef91777532cb80d5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -161,6 +161,23 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==25.3.0"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:752d31105a45e3e01c8c68471db14ae439990b75a35e72b591ca528e2575b28f",
+                "sha256:d125cb11e22817f7a2581bade4bf7b75247b401888890239ceb5d3e902ccaf38"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==1.37.37"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:3eadde6fed95c4cb469cc39d1c3558528b7fa76d23e7e16d4bddc77250431a64",
+                "sha256:eb730ff978f47c02f0c8ed07bccdc0db6d8fa098ed32ac31bee1da0e9be480d1"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.37.37"
         },
         "cachetools": {
             "hashes": [
@@ -732,6 +749,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==0.9.0"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
+                "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.1"
         },
         "joblib": {
             "hashes": [
@@ -2159,6 +2184,14 @@
             ],
             "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==4.9.1"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:757af0f2ac150d3c75bc4177a32355c3862a98d20447b69a0161812992fe0bd4",
+                "sha256:8c8aad92784779ab8688a61aefff3e28e9ebdce43142808eaa3f0b0f402f68b7"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.11.5"
         },
         "safetensors": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ Create a file named `traces.py` with the following code:
     judgment = Tracer(project_name="my_project")
 
     # Or with S3 storage enabled
+    # NOTE: Make sure AWS creds correspond to an account with write access to the specified S3 bucket
     judgment = Tracer(
         project_name="my_project",
         use_s3=True,
-        s3_bucket_name="my-traces-bucket",
+        s3_bucket_name="my-traces-bucket", # Bucket created automatically if it doesn't exist
         s3_aws_access_key_id="your-access-key",  # Optional: defaults to AWS_ACCESS_KEY_ID env var
         s3_aws_secret_access_key="your-secret-key",  # Optional: defaults to AWS_SECRET_ACCESS_KEY env var
         s3_region_name="us-west-1"  # Optional: defaults to AWS_REGION env var or "us-west-1"

--- a/README.md
+++ b/README.md
@@ -57,8 +57,19 @@ Create a file named `traces.py` with the following code:
     from judgeval.common.tracer import Tracer, wrap
     from openai import OpenAI
 
+    # Basic initialization
     client = wrap(OpenAI())
     judgment = Tracer(project_name="my_project")
+
+    # Or with S3 storage enabled
+    judgment = Tracer(
+        project_name="my_project",
+        use_s3=True,
+        s3_bucket_name="my-traces-bucket",
+        s3_aws_access_key_id="your-access-key",  # Optional: defaults to AWS_ACCESS_KEY_ID env var
+        s3_aws_secret_access_key="your-secret-key",  # Optional: defaults to AWS_SECRET_ACCESS_KEY env var
+        s3_region_name="us-west-1"  # Optional: defaults to AWS_REGION env var or "us-west-1"
+    )
 
     @judgment.observe(span_type="tool")
     def my_tool():

--- a/src/judgeval/common/s3_storage.py
+++ b/src/judgeval/common/s3_storage.py
@@ -1,0 +1,77 @@
+import os
+import json
+import boto3
+from typing import Optional
+from datetime import datetime, UTC
+
+class S3Storage:
+    """Utility class for storing and retrieving trace data from S3."""
+    
+    def __init__(
+        self,
+        bucket_name: str,
+        aws_access_key_id: Optional[str] = None,
+        aws_secret_access_key: Optional[str] = None,
+        region_name: Optional[str] = None
+    ):
+        """Initialize S3 storage with credentials and bucket name.
+        
+        Args:
+            bucket_name: Name of the S3 bucket to store traces in
+            aws_access_key_id: AWS access key ID (optional, will use environment variables if not provided)
+            aws_secret_access_key: AWS secret access key (optional, will use environment variables if not provided)
+            region_name: AWS region name (optional, will use environment variables if not provided)
+        """
+        self.bucket_name = bucket_name
+        self.s3_client = boto3.client(
+            's3',
+            aws_access_key_id=aws_access_key_id or os.getenv('AWS_ACCESS_KEY_ID'),
+            aws_secret_access_key=aws_secret_access_key or os.getenv('AWS_SECRET_ACCESS_KEY'),
+            region_name=region_name or os.getenv('AWS_REGION', 'us-west-1')
+        )
+        
+    def save_trace(self, trace_data: dict, trace_id: str, project_name: str) -> str:
+        """Save trace data to S3.
+        
+        Args:
+            trace_data: The trace data to save
+            trace_id: Unique identifier for the trace
+            project_name: Name of the project the trace belongs to
+            
+        Returns:
+            str: S3 key where the trace was saved
+        """
+        # Create a timestamped key for the trace
+        timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
+        s3_key = f"traces/{project_name}/{trace_id}_{timestamp}.json"
+        
+        # Convert trace data to JSON string
+        trace_json = json.dumps(trace_data)
+        
+        # Upload to S3
+        print(f"Uploading trace to S3 at key {s3_key}, in bucket {self.bucket_name} ...")
+        self.s3_client.put_object(
+            Bucket=self.bucket_name,
+            Key=s3_key,
+            Body=trace_json,
+            ContentType='application/json'
+        )
+        
+        return s3_key
+        
+    def get_trace(self, s3_key: str) -> dict:
+        """Retrieve trace data from S3.
+        
+        Args:
+            s3_key: S3 key where the trace is stored
+            
+        Returns:
+            dict: The trace data
+        """
+        response = self.s3_client.get_object(
+            Bucket=self.bucket_name,
+            Key=s3_key
+        )
+        
+        trace_json = response['Body'].read().decode('utf-8')
+        return json.loads(trace_json) 

--- a/src/judgeval/common/tracer.py
+++ b/src/judgeval/common/tracer.py
@@ -204,9 +204,10 @@ class TraceManagerClient:
     - Saving a trace
     - Deleting a trace
     """
-    def __init__(self, judgment_api_key: str, organization_id: str):
+    def __init__(self, judgment_api_key: str, organization_id: str, tracer: Optional["Tracer"] = None):
         self.judgment_api_key = judgment_api_key
         self.organization_id = organization_id
+        self.tracer = tracer
 
     def fetch_trace(self, trace_id: str):
         """
@@ -234,12 +235,13 @@ class TraceManagerClient:
 
     def save_trace(self, trace_data: dict):
         """
-        Saves a trace to the database
+        Saves a trace to the Judgment Supabase and optionally to S3 if configured.
 
         Args:
             trace_data: The trace data to save
             NOTE we save empty traces in order to properly handle async operations; we need something in the DB to associate the async results with
         """
+        # Save to Judgment API
         response = requests.post(
             JUDGMENT_TRACES_SAVE_API_URL,
             json=trace_data,
@@ -255,6 +257,18 @@ class TraceManagerClient:
             raise ValueError(f"Failed to save trace data: Check your Trace name for conflicts, set overwrite=True to overwrite existing traces: {response.text}")
         elif response.status_code != HTTPStatus.OK:
             raise ValueError(f"Failed to save trace data: {response.text}")
+        
+        # If S3 storage is enabled, save to S3 as well
+        if self.tracer and self.tracer.use_s3:
+            try:
+                s3_key = self.tracer.s3_storage.save_trace(
+                    trace_data=trace_data,
+                    trace_id=trace_data["trace_id"],
+                    project_name=trace_data["project_name"]
+                )
+                print(f"Trace also saved to S3 at key: {s3_key}")
+            except Exception as e:
+                warnings.warn(f"Failed to save trace to S3: {str(e)}")
         
         if "ui_results_url" in response.json():
             pretty_str = f"\n🔍 You can view your trace data here: [rgb(106,0,255)][link={response.json()['ui_results_url']}]View Trace[/link]\n"
@@ -353,7 +367,7 @@ class TraceClient:
         self.client: JudgmentClient = tracer.client
         self.entries: List[TraceEntry] = []
         self.start_time = time.time()
-        self.trace_manager_client = TraceManagerClient(tracer.api_key, tracer.organization_id)
+        self.trace_manager_client = TraceManagerClient(tracer.api_key, tracer.organization_id, tracer)
         self.visited_nodes = []
         self.executed_tools = []
         self.executed_node_tools = []
@@ -911,14 +925,24 @@ class Tracer:
         rules: Optional[List[Rule]] = None,  # Added rules parameter
         organization_id: str = os.getenv("JUDGMENT_ORG_ID"),
         enable_monitoring: bool = os.getenv("JUDGMENT_MONITORING", "true").lower() == "true",
-        enable_evaluations: bool = os.getenv("JUDGMENT_EVALUATIONS", "true").lower() == "true"
-        ):
+        enable_evaluations: bool = os.getenv("JUDGMENT_EVALUATIONS", "true").lower() == "true",
+        # S3 configuration
+        use_s3: bool = False,
+        s3_bucket_name: Optional[str] = None,
+        s3_aws_access_key_id: Optional[str] = None,
+        s3_aws_secret_access_key: Optional[str] = None,
+        s3_region_name: Optional[str] = None
+    ):
         if not hasattr(self, 'initialized'):
             if not api_key:
                 raise ValueError("Tracer must be configured with a Judgment API key")
             
             if not organization_id:
                 raise ValueError("Tracer must be configured with an Organization ID")
+            
+            if use_s3 and not s3_bucket_name:
+                raise ValueError("S3 bucket name must be provided when use_s3 is True")
+            
             self.api_key: str = api_key
             self.project_name: str = project_name
             self.client: JudgmentClient = JudgmentClient(judgment_api_key=api_key)
@@ -928,6 +952,17 @@ class Tracer:
             self.initialized: bool = True
             self.enable_monitoring: bool = enable_monitoring
             self.enable_evaluations: bool = enable_evaluations
+            
+            # Initialize S3 storage if enabled
+            self.use_s3 = use_s3
+            if use_s3:
+                from judgeval.common.s3_storage import S3Storage
+                self.s3_storage = S3Storage(
+                    bucket_name=s3_bucket_name,
+                    aws_access_key_id=s3_aws_access_key_id,
+                    aws_secret_access_key=s3_aws_secret_access_key,
+                    region_name=s3_region_name
+                )
         elif hasattr(self, 'project_name') and self.project_name != project_name:
             warnings.warn(
                 f"Attempting to initialize Tracer with project_name='{project_name}' but it was already initialized with "


### PR DESCRIPTION
- Tracer now supports use_s3, s3_bucket_name, s3_aws_access_key_id, s3_aws_secret_access_key, s3_region_name to upload traces to S3 along with Supabase via Judgment API
- Saving is done client-side so that AWS secrets/S3 bucket access does not need to be granted to Judgment backend
- Bucket is created if it doesn't exist
- Updated README