### PR TITLE
Async experiment return

### DIFF
--- a/src/demo/async_evaluation_example.py
+++ b/src/demo/async_evaluation_example.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+Examples demonstrating how to use async evaluation in multiple ways.
+"""
+
+import asyncio
+import os
+import time
+from typing import List
+
+from judgeval.data import Example, ScoringResult
+from judgeval.judgment_client import JudgmentClient
+
+# Get Judgment API key from environment (replace with your actual API key)
+JUDGMENT_API_KEY = os.environ.get("JUDGMENT_API_KEY", "your_api_key_here")
+ORGANIZATION_ID = os.environ.get("ORGANIZATION_ID", "your_organization_id_here")
+
+# Initialize the JudgmentClient
+judgment_client = JudgmentClient(judgment_api_key=JUDGMENT_API_KEY, organization_id=ORGANIZATION_ID)
+
+
+async def example_direct_await():
+    """
+    Example of directly awaiting the Task returned by run_evaluation with async_execution=True.
+    This is the simplest approach and blocks until evaluation is complete.
+    """
+    print("\n=== Example: Direct Await ===")
+    
+    # Create example list
+    examples = [
+        Example(
+            input="What is the capital of France?",
+            actual_output="The capital of France is Paris.",
+            expected_output="Paris"
+        ),
+        Example(
+            input="What is the capital of Italy?",
+            actual_output="Rome is the capital of Italy.",
+            expected_output="Rome"
+        )
+    ]
+    
+    # Set up scorers
+    from judgeval.scorers import AnswerCorrectnessScorer
+    scorers = [AnswerCorrectnessScorer(threshold=0.9)]
+    
+    # Start evaluation asynchronously and get a Task object
+    print("Starting evaluation...")
+    task = judgment_client.run_evaluation(
+        examples=examples,
+        scorers=scorers,
+        model="gpt-4o-mini",
+        project_name="async-examples",
+        eval_run_name="async-example-direct",
+        override=True,
+        async_execution=True
+    )
+    
+    # Directly await the task - this will block until the evaluation is done
+    print("Awaiting results...")
+    results = await task
+    
+    print(f"Evaluation completed! Received {len(results)} results")
+    
+    # Process the results
+    print(results)
+
+
+async def example_with_other_work():
+    """
+    Example of running other work while evaluation is in progress.
+    Shows how to check task status and get results when ready.
+    """
+    print("\n=== Example: Do Other Work While Evaluating ===")
+    
+    # Create example list
+    examples = [
+        Example(
+            input="What is the tallest mountain in the world?",
+            actual_output="Mount Everest is the tallest mountain in the world.",
+            expected_output="Mount Everest"
+        ),
+        Example(
+            input="What is the largest ocean?",
+            actual_output="The Pacific Ocean is the largest ocean on Earth.",
+            expected_output="Pacific Ocean"
+        )
+    ]
+    
+    # Set up scorers
+    from judgeval.scorers import AnswerCorrectnessScorer
+    scorers = [AnswerCorrectnessScorer(threshold=0.9)]
+    
+    # Start evaluation asynchronously and get a Task object
+    print("Starting evaluation...")
+    task = judgment_client.run_evaluation(
+        examples=examples,
+        scorers=scorers,
+        model="gpt-4o-mini",
+        project_name="async-examples",
+        eval_run_name="async-example-other-work",
+        override=True,
+        async_execution=True
+    )
+    
+    # Do other work while evaluation is running
+    print("Doing other work while evaluation runs in the background...")
+    
+    # Simulate other work with a few iterations
+    for i in range(1, 4):
+        print(f"  Doing work iteration {i}...")
+        await asyncio.sleep(2)  # Simulate work with a delay
+        
+        # Check if the evaluation is done
+        if task.done():
+            print("  Evaluation completed during other work!")
+            break
+        else:
+            print("  Evaluation still running...")
+    
+    # Get the results when ready
+    try:
+        if not task.done():
+            print("Waiting for evaluation to complete...")
+            
+        results = await task  # Will return immediately if already done
+        
+        print(results)
+                
+    except Exception as e:
+        print(f"Error in evaluation: {str(e)}")
+        if task.exception():
+            print(f"Task exception: {task.exception()}")
+
+
+async def main():
+    """Run the examples."""
+    # Run the first example: direct await
+    await example_direct_await()
+    
+    # Run the second example: do other work while evaluating
+    await example_with_other_work()
+
+
+if __name__ == "__main__":
+    asyncio.run(main()) 

--- a/src/e2etests/test_async_execution.py
+++ b/src/e2etests/test_async_execution.py
@@ -1,0 +1,255 @@
+import asyncio
+import os
+import pytest
+import uuid
+from typing import List, Dict, Any
+
+from judgeval.data import Example, ScoringResult
+from judgeval.judgment_client import JudgmentClient
+from judgeval.scorers import AnswerCorrectnessScorer, AnswerRelevancyScorer
+from judgeval.common.exceptions import JudgmentAPIError
+
+
+# Skip these tests if API keys aren't set
+pytestmark = pytest.mark.skipif(
+    os.environ.get("JUDGMENT_API_KEY") is None or os.environ.get("JUDGMENT_ORG_ID") is None,
+    reason="JUDGMENT_API_KEY and JUDGMENT_ORG_ID environment variables must be set to run e2e tests"
+)
+
+
+@pytest.fixture
+def examples() -> List[Example]:
+    """Return a list of examples for testing."""
+    return [
+        Example(
+            input="What is the capital of France?",
+            actual_output="The capital of France is Paris.",
+            expected_output="Paris"
+        ),
+        Example(
+            input="What is the capital of Italy?",
+            actual_output="Rome is the capital of Italy.",
+            expected_output="Rome"
+        ),
+        Example(
+            input="What is the capital of Germany?",
+            actual_output="Berlin is the capital of Germany.",
+            expected_output="Berlin"
+        )
+    ]
+
+
+@pytest.fixture
+def tools_examples() -> List[Example]:
+    """Return a list of examples with tools for testing."""
+    return [
+        Example(
+            input="Find the weather in San Francisco",
+            actual_output="The weather in San Francisco is sunny.",
+            expected_output="The weather in San Francisco is sunny and warm.",
+            tools_called=[
+                "get_weather(location='San Francisco')"
+            ],
+            expected_tools=[
+                {
+                    "name": "get_weather",
+                    "parameters": {"location": "San Francisco"}
+                }
+            ]
+        ),
+        Example(
+            input="Search for the latest news about AI",
+            actual_output="Here are the latest news about AI...",
+            expected_output="Here are the latest AI news developments...",
+            tools_called=[
+                "search_news(query='AI', count=5)"
+            ],
+            expected_tools=[
+                {
+                    "name": "search_news",
+                    "parameters": {"query": "AI"}
+                }
+            ]
+        )
+    ]
+
+
+@pytest.fixture
+def judgment_client() -> JudgmentClient:
+    """Return a JudgmentClient instance with API keys from environment."""
+    return JudgmentClient(
+        judgment_api_key=os.environ.get("JUDGMENT_API_KEY"),
+        organization_id=os.environ.get("JUDGMENT_ORG_ID")
+    )
+
+
+@pytest.fixture
+def project_name() -> str:
+    """Return a unique project name for the test."""
+    return f"async-test-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.mark.asyncio
+async def test_async_evaluation_direct_await(judgment_client, examples, project_name):
+    """Test direct awaiting of an async evaluation."""
+    # Set up scorers
+    scorers = [AnswerCorrectnessScorer(threshold=0.9)]
+    
+    # Run the async evaluation
+    task = judgment_client.run_evaluation(
+        examples=examples,
+        scorers=scorers,
+        model="gpt-4o-mini",
+        project_name=project_name,
+        eval_run_name="async-direct-await",
+        async_execution=True
+    )
+    
+    # Await the results directly
+    results = await task
+    
+    # Verify results
+    assert isinstance(results, list)
+    assert len(results) == len(examples)
+    for result in results:
+        assert isinstance(result, ScoringResult)
+        assert result.success is True
+        assert len(result.scorers_data) == len(scorers)
+
+
+@pytest.mark.asyncio
+async def test_async_evaluation_multiple_scorers(judgment_client, tools_examples, project_name):
+    """Test async evaluation with multiple scorers."""
+    # Set up multiple scorers
+    scorers = [
+        AnswerCorrectnessScorer(threshold=0.7),
+        AnswerRelevancyScorer(threshold=0.7)
+    ]
+    
+    # Run the async evaluation
+    task = judgment_client.run_evaluation(
+        examples=tools_examples,
+        scorers=scorers,
+        model="gpt-4o-mini",
+        project_name=project_name,
+        eval_run_name="async-multi-scorers",
+        async_execution=True
+    )
+    
+    # Await the results
+    results = await task
+    
+    # Verify results
+    assert isinstance(results, list)
+    assert len(results) == len(tools_examples)
+    for result in results:
+        assert isinstance(result, ScoringResult)
+        assert result.success is True
+        # Each result should have data from both scorers
+        assert len(result.scorers_data) == len(scorers)
+
+
+@pytest.mark.asyncio
+async def test_async_evaluation_with_other_tasks(judgment_client, examples, project_name):
+    """Test running other async tasks while an evaluation is in progress."""
+    # Set up scorers
+    scorers = [AnswerCorrectnessScorer(threshold=0.9)]
+    
+    # Start the evaluation
+    eval_task = judgment_client.run_evaluation(
+        examples=examples,
+        scorers=scorers,
+        model="gpt-4o-mini",
+        project_name=project_name,
+        eval_run_name="async-with-other-tasks",
+        async_execution=True
+    )
+    
+    # Define a separate task that does other work
+    async def do_other_work():
+        results = []
+        for i in range(3):
+            await asyncio.sleep(0.5)  # Simulate work
+            results.append(f"Work {i} completed")
+        return results
+    
+    # Run both tasks concurrently
+    other_task = asyncio.create_task(do_other_work())
+    done, pending = await asyncio.wait(
+        [eval_task, other_task],
+        return_when=asyncio.ALL_COMPLETED
+    )
+    
+    # Get results from both tasks
+    eval_results = await eval_task
+    other_results = await other_task
+    
+    # Verify evaluation results
+    assert isinstance(eval_results, list)
+    assert len(eval_results) == len(examples)
+    
+    # Verify other work results
+    assert len(other_results) == 3
+    assert all("Work" in result for result in other_results)
+
+
+@pytest.mark.asyncio
+async def test_pull_async_evaluation_results(judgment_client, examples, project_name):
+    """Test pulling results of an async evaluation after it's completed."""
+    # Set up a unique evaluation name
+    eval_run_name = f"async-pull-{uuid.uuid4().hex[:8]}"
+    
+    # Set up scorers
+    scorers = [AnswerCorrectnessScorer(threshold=0.9)]
+    
+    # Run the async evaluation
+    task = judgment_client.run_evaluation(
+        examples=examples,
+        scorers=scorers,
+        model="gpt-4o-mini",
+        project_name=project_name,
+        eval_run_name=eval_run_name,
+        async_execution=True
+    )
+    
+    # Await the results
+    await task
+    
+    # Pull the results using the client API
+    pulled_results = judgment_client.pull_eval(project_name, eval_run_name)
+    
+    # Verify the pulled results
+    assert isinstance(pulled_results, dict)
+    assert "examples" in pulled_results
+    examples_data = pulled_results["examples"]
+    assert len(examples_data) == len(examples)
+    
+    # Check that each example has scorer data
+    for example_data in examples_data:
+        assert "scorer_data" in example_data
+        assert len(example_data["scorer_data"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_cancel_async_evaluation(judgment_client, examples, project_name):
+    """Test cancelling an async evaluation task."""
+    # Set up scorers
+    scorers = [AnswerCorrectnessScorer(threshold=0.9)]
+    
+    # Start the evaluation
+    task = judgment_client.run_evaluation(
+        examples=examples,
+        scorers=scorers,
+        model="gpt-4o-mini",
+        project_name=project_name,
+        eval_run_name="async-cancel",
+        async_execution=True
+    )
+    
+    # Cancel the task after a short delay
+    await asyncio.sleep(0.5)
+    task.cancel()
+    
+    # Try to await the task and expect CancelledError
+    with pytest.raises(asyncio.CancelledError):
+        await task 

--- a/src/judgeval/constants.py
+++ b/src/judgeval/constants.py
@@ -61,6 +61,7 @@ JUDGMENT_TRACES_SAVE_API_URL = f"{ROOT_API}/traces/save/"
 JUDGMENT_TRACES_DELETE_API_URL = f"{ROOT_API}/traces/delete/"
 JUDGMENT_TRACES_ADD_ANNOTATION_API_URL = f"{ROOT_API}/traces/add_annotation/"
 JUDGMENT_ADD_TO_RUN_EVAL_QUEUE_API_URL = f"{ROOT_API}/add_to_run_eval_queue/"
+JUDGMENT_GET_EVAL_STATUS_API_URL = f"{ROOT_API}/get_evaluation_status/"
 # RabbitMQ
 RABBITMQ_HOST = os.getenv("RABBITMQ_HOST", "rabbitmq-networklb-faa155df16ec9085.elb.us-west-1.amazonaws.com")
 RABBITMQ_PORT = os.getenv("RABBITMQ_PORT", 5672)

--- a/src/judgeval/run_evaluation.py
+++ b/src/judgeval/run_evaluation.py
@@ -722,9 +722,12 @@ async def _poll_evaluation_until_complete(eval_name: str, project_name: str, jud
                             example_dict = {k: v for k, v in example_data.items() if k != "scorer_data"}
                             example = Example(**example_dict)
                         
+                        # Calculate success based on whether all scorer_data entries were successful
+                        success = all(scorer_data.success for scorer_data in scorer_data_list) if scorer_data_list else False
+                        
                         # Create ScoringResult
                         scoring_result = ScoringResult(
-                            success=True,  # Assume success if we have results
+                            success=success,  # Set based on all scorer data success values
                             scorers_data=scorer_data_list,
                             data_object=example
                         )

--- a/src/judgeval/run_evaluation.py
+++ b/src/judgeval/run_evaluation.py
@@ -29,13 +29,16 @@ from judgeval.constants import (
     JUDGMENT_EVAL_LOG_API_URL,
     MAX_CONCURRENT_EVALUATIONS,
     JUDGMENT_ADD_TO_RUN_EVAL_QUEUE_API_URL,
-    JUDGMENT_RETRIEVE_SEQUENCE_FROM_TRACE_API_URL
+    JUDGMENT_RETRIEVE_SEQUENCE_FROM_TRACE_API_URL,
+    JUDGMENT_GET_EVAL_STATUS_API_URL,
+    JUDGMENT_EVAL_FETCH_API_URL
 )
 from judgeval.common.exceptions import JudgmentAPIError
 from judgeval.common.logger import (
     debug, 
     info, 
-    error, 
+    error,
+    warning,
     example_logging_context
 )
 from judgeval.evaluation_run import EvaluationRun
@@ -477,7 +480,289 @@ def run_sequence_eval(sequence_run: SequenceRun, override: bool = False, ignore_
     
     
 
-def run_eval(evaluation_run: EvaluationRun, override: bool = False, ignore_errors: bool = True, async_execution: bool = False) -> List[ScoringResult]:
+async def get_evaluation_status(eval_name: str, project_name: str, judgment_api_key: str, organization_id: str) -> Dict:
+    """
+    Gets the status of an async evaluation run.
+    
+    Args:
+        eval_name (str): Name of the evaluation run
+        project_name (str): Name of the project
+        judgment_api_key (str): API key for authentication
+        organization_id (str): Organization ID for the evaluation
+
+    Returns:
+        Dict: Status information including:
+            - status: 'pending', 'running', 'completed', or 'failed'
+            - results: List of ScoringResult objects if completed
+            - error: Error message if failed
+    """
+    try:
+        response = requests.get(
+            JUDGMENT_GET_EVAL_STATUS_API_URL,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {judgment_api_key}",
+                "X-Organization-Id": organization_id
+            },
+            params={
+                "eval_name": eval_name,
+                "project_name": project_name,
+            },
+            verify=True
+        )
+        
+        if not response.ok:
+            error_message = response.json().get('detail', 'An unknown error occurred.')
+            error(f"Error checking evaluation status: {error_message}")
+            raise JudgmentAPIError(error_message)
+            
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        error(f"Failed to check evaluation status: {str(e)}")
+        raise JudgmentAPIError(f"Failed to check evaluation status: {str(e)}")
+
+async def wait_for_evaluation(eval_name: str, project_name: str, judgment_api_key: str, organization_id: str, timeout_seconds: int = 3600, poll_interval_seconds: int = 5) -> List[ScoringResult]:
+    """
+    Wait for an asynchronous evaluation to complete by polling the status endpoint.
+    
+    Args:
+        eval_name (str): Name of the evaluation run
+        project_name (str): Name of the project
+        judgment_api_key (str): API key for authentication
+        organization_id (str): Organization ID for the evaluation
+        timeout_seconds (int, optional): Maximum time to wait in seconds. Defaults to 3600 (1 hour).
+        poll_interval_seconds (int, optional): Time between status checks in seconds. Defaults to 5.
+        
+    Returns:
+        List[ScoringResult]: The evaluation results when complete
+        
+    Raises:
+        TimeoutError: If the evaluation doesn't complete within the timeout period
+        JudgmentAPIError: If there's an API error or the evaluation fails
+    """
+    start_time = time.time()
+    
+    while time.time() - start_time < timeout_seconds:
+        status_response = await get_evaluation_status(
+            eval_name=eval_name,
+            project_name=project_name,
+            judgment_api_key=judgment_api_key,
+            organization_id=organization_id
+        )
+        
+        status = status_response.get("status")
+        
+        if status == "completed":
+            # Evaluation is complete, extract and convert results
+            results_data = status_response.get("results", {})
+            examples_data = results_data.get("examples", [])
+            
+            # Create ScoringResult objects from the raw data
+            scoring_results = []
+            for example_data in examples_data:
+                scorer_data_list = []
+                for raw_scorer_data in example_data.get("scorer_data", []):
+                    scorer_data_list.append(ScorerData(**raw_scorer_data))
+                
+                # Create Example from example data (excluding scorer_data)
+                example_dict = {k: v for k, v in example_data.items() if k != "scorer_data"}
+                example = Example(**example_dict)
+                
+                # Create ScoringResult
+                scoring_result = ScoringResult(
+                    success=True,  # Assume success if we have results
+                    scorers_data=scorer_data_list,
+                    data_object=example
+                )
+                scoring_results.append(scoring_result)
+            
+            return scoring_results
+            
+        elif status == "failed":
+            # Evaluation failed
+            error_message = status_response.get("error", "Unknown error")
+            error(f"Evaluation failed: {error_message}")
+            raise JudgmentAPIError(f"Evaluation failed: {error_message}")
+            
+        # Status is either "pending" or "running", continue polling
+        info(f"Evaluation status: {status}. Waiting for completion...")
+        await asyncio.sleep(poll_interval_seconds)
+    
+    # If we get here, we've timed out
+    error(f"Evaluation timed out after {timeout_seconds} seconds")
+    raise TimeoutError(f"Evaluation timed out after {timeout_seconds} seconds")
+
+async def _poll_evaluation_until_complete(eval_name: str, project_name: str, judgment_api_key: str, organization_id: str, poll_interval_seconds: int = 5, original_examples: Optional[List[Example]] = None) -> List[ScoringResult]:
+    """
+    Polls until the evaluation is complete and returns the results.
+    
+    Args:
+        eval_name (str): Name of the evaluation run
+        project_name (str): Name of the project
+        judgment_api_key (str): API key for authentication
+        organization_id (str): Organization ID for the evaluation
+        poll_interval_seconds (int, optional): Time between status checks in seconds. Defaults to 5.
+        original_examples (List[Example], optional): The original examples sent for evaluation. 
+                                                    If provided, will match results with original examples.
+    
+    Returns:
+        List[ScoringResult]: The evaluation results
+    """
+    poll_count = 0
+    # Create example_id to Example mapping if original examples are provided
+    original_example_map = {}
+    if original_examples:
+        for example in original_examples:
+            original_example_map[example.example_id] = example
+            
+    while True:
+        poll_count += 1
+        try:
+            # Log polling attempt
+            if poll_count % 4 == 0:  # Log every 4th poll to avoid excess logging
+                info(f"Polling for evaluation '{eval_name}' in project '{project_name}' (attempt {poll_count})")
+            
+            # Check status
+            response = requests.get(
+                JUDGMENT_GET_EVAL_STATUS_API_URL,
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {judgment_api_key}",
+                    "X-Organization-Id": organization_id
+                },
+                params={
+                    "eval_name": eval_name,
+                    "project_name": project_name
+                },
+                verify=True
+            )
+            
+            if not response.ok:
+                error_message = response.json().get('detail', 'An unknown error occurred.')
+                error(f"Error checking evaluation status: {error_message}")
+                # Don't raise exception immediately, just log and continue polling
+                await asyncio.sleep(poll_interval_seconds)
+                continue
+            
+            status_data = response.json()
+            status = status_data.get("status")
+            
+            # If complete, get results and return
+            if status == "completed" or status == "complete":
+                info(f"Evaluation '{eval_name}' completed, fetching results...")
+                results_response = requests.post(
+                    JUDGMENT_EVAL_FETCH_API_URL,
+                    headers={
+                        "Content-Type": "application/json",
+                        "Authorization": f"Bearer {judgment_api_key}",
+                        "X-Organization-Id": organization_id
+                    },
+                    json={
+                        "project_name": project_name,
+                        "eval_name": eval_name
+                    },
+                    verify=True
+                )
+                
+                if not results_response.ok:
+                    error_message = results_response.json().get('detail', 'An unknown error occurred.')
+                    error(f"Error fetching evaluation results: {error_message}")
+                    raise JudgmentAPIError(error_message)
+                
+                result_data = results_response.json()
+                
+                if "examples" in result_data:
+                    examples_data = result_data.get("examples", [])
+                    
+                    info(f"Successfully fetched {len(examples_data)} results for evaluation '{eval_name}'")
+                    
+                    # Check for result validity if original examples are provided
+                    if original_example_map:
+                        # Verify all returned examples have matching original examples
+                        has_invalid_results = False
+                        for example_data in examples_data:
+                            example_id = example_data.get("example_id")
+                            if example_id not in original_example_map:
+                                warning(f"Server returned example with ID {example_id} not found in original examples. " +
+                                        f"This indicates stale or incorrect data. Continuing to poll...")
+                                has_invalid_results = True
+                                break
+                        
+                        # If any invalid examples found, continue polling
+                        if has_invalid_results:
+                            info("Detected stale data. Waiting before polling again...")
+                            await asyncio.sleep(poll_interval_seconds)
+                            continue
+                        
+                        # Check if we received the expected number of results
+                        if len(original_examples) != len(examples_data):
+                            warning(f"Expected {len(original_examples)} results but got {len(examples_data)} results. " +
+                                    f"This indicates incomplete data. Continuing to poll...")
+                            await asyncio.sleep(poll_interval_seconds)
+                            continue
+                    
+                    # Create ScoringResult objects from the raw data
+                    scoring_results = []
+                    
+                    for example_data in examples_data:
+                        # Extract example_id from the server response
+                        example_id = example_data.get("example_id")
+                        
+                        # Create ScorerData objects
+                        scorer_data_list = []
+                        for raw_scorer_data in example_data.get("scorer_data", []):
+                            scorer_data_list.append(ScorerData(**raw_scorer_data))
+                        
+                        # Use the original Example object if we have it and the ID matches
+                        if original_example_map:
+                            example = original_example_map[example_id]
+                            debug(f"Matched result with original example {example_id}")
+                        else:
+                            # Create Example from example data (excluding scorer_data) if no original examples provided
+                            example_dict = {k: v for k, v in example_data.items() if k != "scorer_data"}
+                            example = Example(**example_dict)
+                        
+                        # Create ScoringResult
+                        scoring_result = ScoringResult(
+                            success=True,  # Assume success if we have results
+                            scorers_data=scorer_data_list,
+                            data_object=example
+                        )
+                        scoring_results.append(scoring_result)
+                    
+                    return scoring_results
+                else:
+                    # No examples found
+                    info(f"No example results found for completed evaluation '{eval_name}'")
+                    return []
+            
+            elif status == "failed":
+                # Evaluation failed
+                error_message = status_data.get("error", "Unknown error")
+                error(f"Evaluation '{eval_name}' failed: {error_message}")
+                raise JudgmentAPIError(f"Evaluation failed: {error_message}")
+            
+            elif status == "pending" or status == "running":
+                # Only log occasionally for pending/running to avoid flooding logs
+                if poll_count % 4 == 0:
+                    info(f"Evaluation '{eval_name}' status: {status}")
+            
+            # Wait before checking again
+            await asyncio.sleep(poll_interval_seconds)
+            
+        except Exception as e:
+            if isinstance(e, JudgmentAPIError):
+                raise
+                
+            # For other exceptions, log and continue polling
+            error(f"Error checking evaluation status: {str(e)}")
+            if poll_count > 20:  # Only raise exception after many failed attempts
+                raise JudgmentAPIError(f"Error checking evaluation status after {poll_count} attempts: {str(e)}")
+                
+            # Continue polling after a delay
+            await asyncio.sleep(poll_interval_seconds)
+
+def run_eval(evaluation_run: EvaluationRun, override: bool = False, ignore_errors: bool = True, async_execution: bool = False) -> Union[List[ScoringResult], asyncio.Task]:
     """
     Executes an evaluation of `Example`s using one or more `Scorer`s
 
@@ -485,21 +770,12 @@ def run_eval(evaluation_run: EvaluationRun, override: bool = False, ignore_error
         evaluation_run (EvaluationRun): Stores example and evaluation together for running
         override (bool, optional): Whether to override existing evaluation run with same name. Defaults to False.
         ignore_errors (bool, optional): Whether to ignore scorer errors during evaluation. Defaults to True.
+        async_execution (bool, optional): Whether to execute the evaluation asynchronously. Defaults to False.
     
-        Args: 
-            project_name (str): The name of the project the evaluation results belong to
-            eval_name (str): The name of the evaluation run
-            examples (List[Example]): The examples to evaluate
-            scorers (List[Union[JudgmentScorer, JudgevalScorer]]): A list of scorers to use for evaluation
-            model (str): The model used as a judge when using LLM as a Judge
-            aggregator (Optional[str]): The aggregator to use for evaluation if using Mixture of Judges
-            metadata (Optional[Dict[str, Any]]): Additional metadata to include for this evaluation run, e.g. comments, dataset name, purpose, etc.
-            judgment_api_key (Optional[str]): The API key for running evaluations on the Judgment API
-            log_results (bool): Whether to log the results to the Judgment API
-            rules (Optional[List[Rule]]): Rules to evaluate against scoring results
-
     Returns:
-        List[ScoringResult]: The results of the evaluation. Each result is a dictionary containing the fields of a `ScoringResult` object.
+        Union[List[ScoringResult], asyncio.Task]: 
+            - If async_execution is False, returns a list of ScoringResult objects
+            - If async_execution is True, returns a Task that will resolve to a list of ScoringResult objects when awaited
     """
 
     # Call endpoint to check to see if eval run name exists (if we DON'T want to override and DO want to log results)
@@ -570,21 +846,45 @@ def run_eval(evaluation_run: EvaluationRun, override: bool = False, ignore_error
     if async_execution:
         if len(local_scorers) > 0:
             error("Local scorers are not supported in async execution")
+            raise ValueError("Local scorers are not supported in async execution")
             
         check_examples(evaluation_run.examples, evaluation_run.scorers)
         info("Starting async evaluation")
-        payload = evaluation_run.model_dump(warnings=False)
-        requests.post(
-            JUDGMENT_ADD_TO_RUN_EVAL_QUEUE_API_URL,
-            headers={
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {evaluation_run.judgment_api_key}",
-                "X-Organization-Id": evaluation_run.organization_id
-            },
-            json=payload,
-            verify=True
-        )
-        print("Successfully added evaluation to queue")
+        
+        async def _async_evaluation_workflow():
+            # Create a payload
+            payload = evaluation_run.model_dump(warnings=False)
+            
+            # Send the evaluation to the queue
+            response = requests.post(
+                JUDGMENT_ADD_TO_RUN_EVAL_QUEUE_API_URL,
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {evaluation_run.judgment_api_key}",
+                    "X-Organization-Id": evaluation_run.organization_id
+                },
+                json=payload,
+                verify=True
+            )
+            
+            if not response.ok:
+                error_message = response.json().get('detail', 'An unknown error occurred.')
+                error(f"Error adding evaluation to queue: {error_message}")
+                raise JudgmentAPIError(error_message)
+                
+            info(f"Successfully added evaluation '{evaluation_run.eval_name}' to queue")
+            
+            # Poll until the evaluation is complete
+            return await _poll_evaluation_until_complete(
+                eval_name=evaluation_run.eval_name,
+                project_name=evaluation_run.project_name,
+                judgment_api_key=evaluation_run.judgment_api_key,
+                organization_id=evaluation_run.organization_id,
+                original_examples=evaluation_run.examples  # Pass the original examples
+            )
+        
+        # Create and return a task that can be awaited
+        return asyncio.create_task(_async_evaluation_workflow())
     else:
         if judgment_scorers:
             # Execute evaluation using Judgment API

--- a/src/tests/test_async_execution.py
+++ b/src/tests/test_async_execution.py
@@ -1,0 +1,134 @@
+import asyncio
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock
+
+from judgeval.data import Example, ScoringResult
+from judgeval.judgment_client import JudgmentClient
+from judgeval.scorers import APIJudgmentScorer
+from judgeval.common.exceptions import JudgmentAPIError
+
+
+@pytest.fixture
+def examples():
+    """Return a list of test examples."""
+    return [
+        Example(
+            input="What is the capital of France?",
+            actual_output="The capital of France is Paris.",
+            expected_output="Paris"
+        ),
+        Example(
+            input="What is the capital of Italy?",
+            actual_output="Rome is the capital of Italy.",
+            expected_output="Rome"
+        )
+    ]
+
+
+@pytest.fixture
+def scorers():
+    """Return a list of API scorers."""
+    return [
+        APIJudgmentScorer(
+            name="Test Scorer",
+            score_type="answer_correctness",
+            threshold=0.7
+        )
+    ]
+
+
+@pytest.fixture
+def judgment_client():
+    """Return a mocked JudgmentClient."""
+    with patch('judgeval.judgment_client.validate_api_key', return_value=(True, "valid")):
+        client = JudgmentClient(judgment_api_key="fake_key", organization_id="fake_org")
+        return client
+
+
+@pytest.mark.asyncio
+async def test_async_execution_returns_task(judgment_client, examples, scorers):
+    """Test that run_evaluation with async_execution=True returns a Task."""
+    # Patch the run_eval function to return a Task
+    with patch('judgeval.judgment_client.run_eval') as mock_run_eval:
+        # Create a mock task
+        mock_task = asyncio.create_task(asyncio.sleep(0))
+        mock_run_eval.return_value = mock_task
+        
+        # Call run_evaluation with async_execution=True
+        result = judgment_client.run_evaluation(
+            examples=examples,
+            scorers=scorers,
+            async_execution=True
+        )
+        
+        # Check that run_eval was called with async_execution=True
+        mock_run_eval.assert_called_once()
+        call_args = mock_run_eval.call_args[1]
+        assert call_args['async_execution'] is True
+        
+        # Check that the result is a Task
+        assert isinstance(result, asyncio.Task)
+
+
+
+@pytest.mark.asyncio
+async def test_async_execution_result_awaitable(judgment_client, examples, scorers):
+    """Test that the Task returned by run_evaluation can be awaited and returns results."""
+    # Create a mock ScoringResult to be returned by the task
+    mock_result = [ScoringResult(
+        success=True,
+        scorers_data=[],
+        data_object=examples[0],
+        name=None,
+        trace_id=None,
+        run_duration=None,
+        evaluation_cost=None
+    )]
+    
+    # Create an async function that returns the mock result
+    async def mock_async_workflow():
+        await asyncio.sleep(0.1)  # Small delay
+        return mock_result
+    
+    # Patch run_eval to return a real task with our mock workflow
+    with patch('judgeval.judgment_client.run_eval') as mock_run_eval:
+        mock_task = asyncio.create_task(mock_async_workflow())
+        mock_run_eval.return_value = mock_task
+        
+        # Call run_evaluation with async_execution=True
+        task = judgment_client.run_evaluation(
+            examples=examples,
+            scorers=scorers,
+            async_execution=True
+        )
+        
+        # Await the task and check the result
+        result = await task
+        assert result == mock_result
+
+
+@pytest.mark.asyncio
+async def test_async_execution_error_handling(judgment_client, examples, scorers):
+    """Test that errors in async execution are properly propagated."""
+    # Create an async function that raises an error
+    async def mock_async_error():
+        await asyncio.sleep(0.1)  # Small delay
+        raise JudgmentAPIError("Test API error")
+    
+    # Patch run_eval to return a task that will raise an error
+    with patch('judgeval.judgment_client.run_eval') as mock_run_eval:
+        mock_task = asyncio.create_task(mock_async_error())
+        mock_run_eval.return_value = mock_task
+        
+        # Call run_evaluation with async_execution=True
+        task = judgment_client.run_evaluation(
+            examples=examples,
+            scorers=scorers,
+            async_execution=True
+        )
+        
+        # Await the task and check that the error is propagated
+        with pytest.raises(JudgmentAPIError) as excinfo:
+            await task
+        
+        assert "Test API error" in str(excinfo.value) 


### PR DESCRIPTION
## 📝 Summary

Allow for return of a Task object for running Async Example instead of running just Sync version

## 🎯 Purpose

Our current Async Run Evaluation is returning nothing when Async Execution is on, so it is bad UX. Created a new task object that is awaitable for user to have the same behavior as Sync run evaluation

Merge with this: https://github.com/JudgmentLabs/judgment/pull/342

## 🎥 Demo of Changes

Watch soon

## 🧪 Testing

Run E2Etest and add new test

## ✅ Checklist

- [x] Self-review
- [x] Video demo of changes
- [x] Unit Tests and CI/CD tests are passing
- [ ] Reviewers assigned


## 📌 Linear Issue

https://linear.app/judgment/issue/JUD-921/add-async-evaluation-object

## ✏️ Additional Notes

<!-- Any additional information that doesn't fit into the other sections -->
