### PR TITLE
Staging and auto package release

### DIFF
--- a/.github/workflows/ci-staging.yaml
+++ b/.github/workflows/ci-staging.yaml
@@ -90,4 +90,4 @@ jobs:
         run: |      
           SECRET_VARS=$(aws secretsmanager get-secret-value --secret-id gh-actions-stg-judgeval/api-keys/judgeval --query SecretString --output text)
           export $(echo "$SECRET_VARS" | jq -r 'to_entries | .[] | "\(.key)=\(.value)"')
-          pipenv run pytest --durations=0 ./e2etests
+          timeout 600s pipenv run pytest --durations=0 ./e2etests

--- a/.github/workflows/ci-staging.yaml
+++ b/.github/workflows/ci-staging.yaml
@@ -78,16 +78,16 @@ jobs:
 
       - name: Check if server is running
         run: |
-          if ! curl -s https://api.judgmentlabs.ai/health > /dev/null; then
-            echo "Production Judgment server is not running properly. Check logs on AWS CloudWatch for more details."
+          if ! curl -s https://staging.api.judgmentlabs.ai/health > /dev/null; then
+            echo "Staging Judgment server is not running properly. Check logs on AWS CloudWatch for more details."
             exit 1
           else
-            echo "Server is running."
+            echo "Staging server is running."
           fi
         
       - name: Run E2E tests
         working-directory: src
         run: |      
-          SECRET_VARS=$(aws secretsmanager get-secret-value --secret-id gh-actions-judgeval/api-keys/judgeval --query SecretString --output text)
+          SECRET_VARS=$(aws secretsmanager get-secret-value --secret-id gh-actions-stg-judgeval/api-keys/judgeval --query SecretString --output text)
           export $(echo "$SECRET_VARS" | jq -r 'to_entries | .[] | "\(.key)=\(.value)"')
           pipenv run pytest --durations=0 ./e2etests

--- a/.github/workflows/ci-staging.yaml
+++ b/.github/workflows/ci-staging.yaml
@@ -1,10 +1,13 @@
-name: CI Tests
+name: Staging CI Tests
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
-      - main
+      - staging
+  push:
+    branches:
+      - justin/staging-and-auto-release
 
 permissions: read-all
 
@@ -44,9 +47,9 @@ jobs:
           cd src
           pipenv run pytest tests
 
-  run-e2e-tests:
+  run-e2e-tests-staging:
     if: "!contains(github.actor, '[bot]')"  # Exclude if the actor is a bot
-    name: E2E Tests
+    name: Staging E2E Tests
     runs-on: ubuntu-latest
     steps:
       - name: Wait for turn
@@ -54,7 +57,7 @@ jobs:
         with:
           poll-interval-seconds: 10
           same-branch-only: false
-          job-to-wait-for: "E2E Tests"
+          job-to-wait-for: "Staging E2E Tests"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ci-staging.yaml
+++ b/.github/workflows/ci-staging.yaml
@@ -5,9 +5,6 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - staging
-  push:
-    branches:
-      - justin/staging-and-auto-release
 
 permissions: read-all
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,4 +90,4 @@ jobs:
         run: |      
           SECRET_VARS=$(aws secretsmanager get-secret-value --secret-id gh-actions-judgeval/api-keys/judgeval --query SecretString --output text)
           export $(echo "$SECRET_VARS" | jq -r 'to_entries | .[] | "\(.key)=\(.value)"')
-          pipenv run pytest --durations=0 ./e2etests
+          timeout 600s pipenv run pytest --durations=0 ./e2etests

--- a/.github/workflows/merge-to-main.yaml
+++ b/.github/workflows/merge-to-main.yaml
@@ -1,0 +1,32 @@
+name: Enforce Main Branch Protection
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  validate-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name
+        run: |
+          # Get the base and source branch names
+          BASE_BRANCH="${{ github.base_ref }}"
+          SOURCE_BRANCH="${{ github.head_ref }}"
+
+          echo "BASE_BRANCH: $BASE_BRANCH"
+          echo "SOURCE_BRANCH: $SOURCE_BRANCH"
+          
+          # Only run validation if the base branch is main
+          if [[ "$BASE_BRANCH" != "main" ]]; then
+            echo "Skipping branch validation - not targeting main branch"
+            exit 0
+          fi
+          
+          # Check if the source branch is staging or starts with hotfix/
+          if [[ "$SOURCE_BRANCH" != "staging" && ! "$SOURCE_BRANCH" =~ ^hotfix/ ]]; then
+            echo "::error::Pull requests to main can only be created from 'staging' or 'hotfix/*' branches. Current branch: $SOURCE_BRANCH"
+            exit 1
+          fi
+          
+          echo "Branch validation passed. Source branch: $SOURCE_BRANCH"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,92 @@
+name: Release on Main Merge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.bump_tag.outputs.new_version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Get latest version
+        id: get_version
+        run: |
+          version=$(curl -s https://pypi.org/pypi/judgeval/json | jq -r .info.version)
+          echo "latest_version=$version" >> $GITHUB_OUTPUT
+
+      - name: Bump version and create new tag
+        id: bump_tag
+        run: |
+          latest_version=${{ steps.get_version.outputs.latest_version }}
+          echo "Latest version: $latest_version"
+
+          # Extract version numbers
+          IFS='.' read -r major minor patch <<< "$latest_version"
+
+          # Bump patch version
+          patch=$((patch + 1))
+          new_version="$major.$minor.$patch"
+
+          echo "New version: $new_version"
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
+
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git tag v$new_version
+          git push origin v$new_version
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.bump_tag.outputs.new_version }}
+          generate_release_notes: true
+          body: |
+            You can find this package release on PyPI: https://pypi.org/project/judgeval/${{ steps.bump_tag.outputs.new_version }}/
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Bump pyproject.toml version
+        run: |
+          python update_version.py ${{ steps.bump_tag.outputs.new_version }}
+
+      - name: Build PyPI package
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Create PyPI release
+        run: |
+          python -m pip install --upgrade twine
+          python -m twine upload --repository pypi -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} dist/*
+
+  cleanup:
+    needs: release
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Authenticate GitHub CLI
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
+      - name: Delete tag and release
+        run: |
+          gh release delete v${{ needs.release.outputs.new_version }} --yes
+          git push --delete origin v${{ needs.release.outputs.new_version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "judgeval"
-version = "0.0.32"
+version = "<version_placeholder>"
 authors = [
     { name="Andrew Li", email="andrew@judgmentlabs.ai" },
     { name="Alex Shan", email="alex@judgmentlabs.ai" },

--- a/update_version.py
+++ b/update_version.py
@@ -8,16 +8,24 @@ new_version = sys.argv[1]
 version_placeholder = "<version_placeholder>"
 found = False
 
-with open("pyproject.toml", "r") as f:
-    lines = f.readlines()
+try:
+    with open("pyproject.toml", "r") as f:
+        lines = f.readlines()
+except IOError as e:
+    print(f"Error: Failed to read 'pyproject.toml': {e}")
+    sys.exit(1)
 
-with open("pyproject.toml", "w") as f:
-    for line in lines:
-        if not found and version_placeholder in line:
-            f.write(line.replace(version_placeholder, new_version))
-            found = True
-        else:
-            f.write(line)
+try:
+    with open("pyproject.toml", "w") as f:
+        for line in lines: # Assumes 'lines' was successfully read earlier
+            if not found and version_placeholder in line:
+                f.write(line.replace(version_placeholder, new_version))
+                found = True
+            else:
+                f.write(line)
+except IOError as e:
+    print(f"Error: Failed to write to 'pyproject.toml': {e}")
+    sys.exit(1)
 
 if not found:
     print("Warning: No '<version_placeholder>' found in pyproject.toml")

--- a/update_version.py
+++ b/update_version.py
@@ -1,0 +1,23 @@
+import sys
+
+if len(sys.argv) != 2:
+    print("Usage: python set_version.py <new_version>")
+    sys.exit(1)
+
+new_version = sys.argv[1]
+version_placeholder = "<version_placeholder>"
+found = False
+
+with open("pyproject.toml", "r") as f:
+    lines = f.readlines()
+
+with open("pyproject.toml", "w") as f:
+    for line in lines:
+        if not found and version_placeholder in line:
+            f.write(line.replace(version_placeholder, new_version))
+            found = True
+        else:
+            f.write(line)
+
+if not found:
+    print("Warning: No '<version_placeholder>' found in pyproject.toml")

--- a/update_version.py
+++ b/update_version.py
@@ -21,3 +21,4 @@ with open("pyproject.toml", "w") as f:
 
 if not found:
     print("Warning: No '<version_placeholder>' found in pyproject.toml")
+    sys.exit(1)


### PR DESCRIPTION
- Added automated PyPI and GitHub releases:
   - Merging to main with triggers both a GitHub release and a PyPI release
      - Release notes currently just link to the PyPI release
   - Versioning is currently handled by incrementing patch number (third number) of the the latest PyPI version. This can be changed later
   - If PyPI release fails, GitHub release will be reverted (both tag and release)
- Added staging CI
   - Branch protection: only staging and hotfix/* can be merged into main
   - Staging E2E tests against staging.api.judgmentlabs.ai