### PR TITLE
Agent state

### DIFF
--- a/src/judgeval/common/tracer.py
+++ b/src/judgeval/common/tracer.py
@@ -1067,7 +1067,7 @@ class Tracer:
 
         rprint(f"[bold]{label}:[/bold] {msg}")
     
-    def identify(self, identifier: str, track_state: bool = False, track_attributes: Optional[List[str]] = None):
+    def identify(self, identifier: str, track_state: bool = False, track_attributes: Optional[List[str]] = None, field_mappings: Optional[Dict[str, str]] = None):
         """
         Class decorator that associates a class with a custom identifier.
         
@@ -1091,7 +1091,8 @@ class Tracer:
             self.class_identifiers[class_name] = {
                 "identifier": identifier,
                 "track_state": track_state,
-                "track_attributes": track_attributes
+                "track_attributes": track_attributes,
+                "field_mappings": field_mappings or {}
             }
             return cls
         
@@ -1105,13 +1106,20 @@ class Tracer:
             instance: The instance to capture the state of
         """
         track_attributes = class_config.get('track_attributes')
+        field_mappings = class_config.get('field_mappings')
         
         if track_attributes:
-            # Track only specified attributes
-            return {attr: getattr(instance, attr, None) for attr in track_attributes}
+        
+            state = {attr: getattr(instance, attr, None) for attr in track_attributes}
         else:
-            # Track all non-private attributes
-            return {k: v for k, v in instance.__dict__.items() if not k.startswith('_')}
+
+            state = {k: v for k, v in instance.__dict__.items() if not k.startswith('_')}
+
+        if field_mappings:
+            state['field_mappings'] = field_mappings
+
+        return state
+        
         
     def _get_instance_state_if_tracked(self, args):
         """

--- a/src/judgeval/data/trace.py
+++ b/src/judgeval/data/trace.py
@@ -36,7 +36,7 @@ class TraceSpan(BaseModel):
     state_after: Optional[Dict[str, Any]] = None
 
     def model_dump(self, **kwargs):
-        result = {
+        return {
             "span_id": self.span_id,
             "trace_id": self.trace_id,
             "depth": self.depth,

--- a/src/judgeval/data/trace.py
+++ b/src/judgeval/data/trace.py
@@ -32,9 +32,11 @@ class TraceSpan(BaseModel):
     additional_metadata: Optional[Dict[str, Any]] = None
     has_evaluation: Optional[bool] = False
     agent_name: Optional[str] = None
+    state_before: Optional[Dict[str, Any]] = None
+    state_after: Optional[Dict[str, Any]] = None
 
     def model_dump(self, **kwargs):
-        return {
+        result = {
             "span_id": self.span_id,
             "trace_id": self.trace_id,
             "depth": self.depth,
@@ -49,7 +51,9 @@ class TraceSpan(BaseModel):
             "span_type": self.span_type,
             "usage": self.usage.model_dump() if self.usage else None,
             "has_evaluation": self.has_evaluation,
-            "agent_name": self.agent_name
+            "agent_name": self.agent_name,
+            "state_before": self.state_before,
+            "state_after": self.state_after 
         }
     
     def print_span(self):

--- a/src/judgeval/run_evaluation.py
+++ b/src/judgeval/run_evaluation.py
@@ -429,7 +429,7 @@ def run_trace_eval(trace_run: TraceRun, override: bool = False, ignore_errors: b
     debug("Processing API results")
     # TODO: allow for custom scorer on traces
     if trace_run.log_results:
-        pretty_str = run_with_spinner("Logging Results: ", log_evaluation_results, response_data["results"], trace_run)
+        pretty_str = run_with_spinner("Logging Results: ", log_evaluation_results, response_data["agent_results"], trace_run)
         rprint(pretty_str)
 
     return scoring_results


### PR DESCRIPTION
## 📝 Summary

this PR allows for the checking of an agents internal state before a tool is called and after a tool is called. This occurs in the tracer object, and in the observe decorator definition to track when a new span is being created.

## 🎯 Purpose

this is neccessary for developers to understand the state of their agent before and after a tool call in case the tool is able to access the agents variables and what data the agent stores/

## 🎥 Demo of Changes

on slack

## 🧪 Testing

manually tested with mock-agent, wordproblemsolver

## ✅ Checklist

- [ X] Self-review
- [X ] Video demo of changes
- [X ] Unit Tests and CI/CD tests are passing
- [ X] Reviewers assigned


## 📌 Linear Issue

<!-- Reference to associated Linear ticket, e.g., ABC-123 -->

## ✏️ Additional Notes

<!-- Any additional information that doesn't fit into the other sections -->
