### PR TITLE
Upgrade timestamp (JUD-1114)

### DIFF
--- a/src/judgeval/common/tracer.py
+++ b/src/judgeval/common/tracer.py
@@ -23,7 +23,7 @@ from contextlib import (
     AbstractContextManager,
 )  # Import context manager bases
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from http import HTTPStatus
 from typing import (
     Any,
@@ -799,7 +799,7 @@ class TraceClient:
             "trace_id": self.trace_id,
             "name": self.name,
             "project_name": self.project_name,
-            "created_at": datetime.utcfromtimestamp(time.time()).isoformat(),
+            "created_at": datetime.fromtimestamp(time.time(), timezone.utc).isoformat(),
             "duration": total_duration,
             "trace_spans": [span.model_dump() for span in self.trace_spans],
             "evaluation_runs": [run.model_dump() for run in self.evaluation_runs],
@@ -2066,8 +2066,8 @@ class Tracer:
                             complete_trace_data = {
                                 "trace_id": current_trace.trace_id,
                                 "name": current_trace.name,
-                                "created_at": datetime.utcfromtimestamp(
-                                    current_trace.start_time
+                                "created_at": datetime.fromtimestamp(
+                                    current_trace.start_time, timezone.utc
                                 ).isoformat(),
                                 "duration": current_trace.get_duration(),
                                 "trace_spans": [
@@ -2214,8 +2214,8 @@ class Tracer:
                             complete_trace_data = {
                                 "trace_id": current_trace.trace_id,
                                 "name": current_trace.name,
-                                "created_at": datetime.utcfromtimestamp(
-                                    current_trace.start_time
+                                "created_at": datetime.fromtimestamp(
+                                    current_trace.start_time, timezone.utc
                                 ).isoformat(),
                                 "duration": current_trace.get_duration(),
                                 "trace_spans": [

--- a/src/judgeval/integrations/langgraph.py
+++ b/src/judgeval/integrations/langgraph.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional, Sequence
 from uuid import UUID
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from judgeval.common.tracer import (
     TraceClient,
@@ -308,8 +308,8 @@ class JudgevalCallbackHandler(BaseCallbackHandler):
                     complete_trace_data = {
                         "trace_id": self._trace_client.trace_id,
                         "name": self._trace_client.name,
-                        "created_at": datetime.utcfromtimestamp(
-                            self._trace_client.start_time
+                        "created_at": datetime.fromtimestamp(
+                            self._trace_client.start_time, timezone.utc
                         ).isoformat(),
                         "duration": self._trace_client.get_duration(),
                         "trace_spans": [
@@ -518,8 +518,8 @@ class JudgevalCallbackHandler(BaseCallbackHandler):
                 complete_trace_data = {
                     "trace_id": trace_client.trace_id,
                     "name": trace_client.name,
-                    "created_at": datetime.utcfromtimestamp(
-                        trace_client.start_time
+                    "created_at": datetime.fromtimestamp(
+                        trace_client.start_time, timezone.utc
                     ).isoformat(),
                     "duration": trace_client.get_duration(),
                     "trace_spans": [


### PR DESCRIPTION
## 📝 Summary

We are using a deprecrated method:
datetime.utcfromtimestamp(self.start_time).isoformat()

Refactor to use a newer method:
datetime.fromtimestamp(self.start_time, timezone.utc).isoformat()

## 🎥 Demo of Changes

<!-- Add a short 1-3 minute video describing/demoing the changes -->

## ✅ Checklist

- [ ] Tagged Linear ticket in PR title. Ie. PR Title (JUD-XXXX)
- [ ] Video demo of changes
- [ ] Reviewers assigned
