### PR TITLE
Add set_reward_score function for Traces

### DIFF
--- a/src/judgeval/common/tracer.py
+++ b/src/judgeval/common/tracer.py
@@ -797,6 +797,15 @@ class TraceClient:
         """
         self.update_metadata({"tags": tags})
 
+    def set_reward_score(self, reward_score: Union[float, Dict[str, float]]):
+        """
+        Set the reward score for this trace to be used for RL or SFT.
+
+        Args:
+            reward_score: The reward score to set
+        """
+        self.update_metadata({"reward_score": reward_score})
+
 
 def _capture_exception_for_trace(
     current_trace: Optional["TraceClient"], exc_info: ExcInfo
@@ -2271,6 +2280,19 @@ class Tracer:
             current_trace.set_tags(tags)
         else:
             judgeval_logger.warning("No current trace found, cannot set tags")
+
+    def set_reward_score(self, reward_score: Union[float, Dict[str, float]]):
+        """
+        Set the reward score for this trace to be used for RL or SFT.
+
+        Args:
+            reward_score: The reward score to set
+        """
+        current_trace = self.get_current_trace()
+        if current_trace:
+            current_trace.set_reward_score(reward_score)
+        else:
+            judgeval_logger.warning("No current trace found, cannot set reward score")
 
     def get_background_span_service(self) -> Optional[BackgroundSpanService]:
         """Get the background span service instance."""


### PR DESCRIPTION
## 📝 Summary

<!-- Add your list of changes, make it a list to improve the PR reviewers' experience. Ie:
- [ ] 1. Remove duplicate filter table
- [ ] 2. Reenabled filtering on new ExperimentRunsTableClient component, reapplied filtering changes
- [ ] 3. Added only search and filter when enter is pressed or apply filter is pressed
- [ ] 4. Error message for applying incomplete filters
- [ ] 5. Deletion should now work again for table
- [ ] 6. Comparison should now work again for table
-->
- [ ] 1. Try setting the reward score by calling `judgment.set_reward_score(0.8)` and checking the exported trace for: 
```
[
  {
    "trace_id": "3484ecbd-24df-4a9f-8865-c2db25aacfe1",
    "metadata": {
      "reward_score": 0.8
    },
...
]
```
- [ ] 2. Try setting the reward score with `judgment.set_reward_score({"score_1": 0.8, "score_2": 0.4})`  and checking the exported trace for: 
```
[
  {
    "trace_id": "3484ecbd-24df-4a9f-8865-c2db25aacfe1",
    "metadata": {
      "reward_score": {"score_1": 0.8, "score_2": 0.4}
    },
...
]
```

## 🎥 Demo of Changes

<!-- Add a short 1-3 minute video describing/demoing the changes -->

## ✅ Checklist

- [ ] Tagged Linear ticket in PR title. Ie. PR Title (JUD-XXXX)
- [ ] Video demo of changes
- [ ] Reviewers assigned
- [ ] Docs updated ([if necessary](https://github.com/JudgmentLabs/docs))
- [ ] Cookbooks updated ([if necessary](https://github.com/JudgmentLabs/judgment-cookbook))
