### PR TITLE
Added Support for Groq Client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ dependencies = [
     "langchain-openai",
     "langchain-anthropic",
     "langchain-core",
+    "langchain-groq",
     "google-genai",
+    "groq",
     "boto3",
     "matplotlib>=3.10.3",
 ]

--- a/src/judgeval/common/tracer.py
+++ b/src/judgeval/common/tracer.py
@@ -2758,12 +2758,12 @@ def _format_response_output_data(client: ApiClient, response: Any) -> tuple:
     completion_tokens = 0
     model_name = None
     if isinstance(client, (OpenAI, Together, AsyncOpenAI, AsyncTogether)):
-        model_name = f"groq/{response.model}"
+        model_name = response.model
         prompt_tokens = response.usage.input_tokens
         completion_tokens = response.usage.output_tokens
         message_content = response.output
     elif isinstance(client, (Groq, AsyncGroq)):
-        model_name = response.model
+        model_name = f"groq/{response.model}"
         prompt_tokens = response.usage.input_tokens
         completion_tokens = response.usage.output_tokens
         message_content = response.output


### PR DESCRIPTION
## 📝 Summary

<!-- Provide a brief description of the changes introduced by this PR -->
Added Support for Groq as direct client for trace. Nothing fancy. So poor peple like me can use it :)

<!-- Supported Groq Model -->
llama-3.1-8b-instant
llama-3.1-70b-versatile
llama3-8b-8192
llama3-70b-8192
llama2-70b-4096
mixtral-8x7b-32768
gemma-7b-it

<!-- Warning -->
I have not written Test for it (i.e. no changes in e2etests/test_tracer.py). Just a simple test file and tried all the above models. Not in the commit as I assume @justinsheu is writing them.