### PR TITLE
Fix Override race condition evals (JUD-1678)

### DIFF
--- a/src/e2etests/test_dataset_operations.py
+++ b/src/e2etests/test_dataset_operations.py
@@ -11,6 +11,17 @@ from judgeval.dataset import Dataset
 
 
 def test_create_dataset(client: JudgmentClient, project_name: str, random_name: str):
+    """Test dataset creation"""
+    dataset = Dataset.create(
+        name=random_name,
+        project_name=project_name,
+    )
+    dataset.delete()
+
+
+def test_create_dataset_with_example(
+    client: JudgmentClient, project_name: str, random_name: str
+):
     """Test dataset creation and manipulation."""
     dataset = Dataset.create(
         name=random_name,

--- a/src/judgeval/dataset.py
+++ b/src/judgeval/dataset.py
@@ -35,6 +35,7 @@ class Dataset:
         for e in examples:
             if isinstance(e, dict) and isinstance(e.get("data"), dict):
                 e.update(e.pop("data"))
+        judgeval_logger.info(f"Succesfully retrieved dataset {name}!")
         return cls(
             name=name,
             project_name=project_name,
@@ -68,6 +69,7 @@ class Dataset:
             traces=[t.model_dump() for t in traces],
             overwrite=overwrite,
         )
+        judgeval_logger.info(f"Succesfull created dataset {name}!")
         return cls(
             name=name,
             project_name=project_name,

--- a/src/judgeval/run_evaluation.py
+++ b/src/judgeval/run_evaluation.py
@@ -537,7 +537,12 @@ def run_eval(
             judgment_api_key,
             evaluation_run.organization_id,
         )
-
+    if override:
+        api_client = JudgmentApiClient(judgment_api_key, evaluation_run.organization_id)
+        api_client.delete_evaluation_results(
+            project_name=evaluation_run.project_name,
+            eval_names=[evaluation_run.eval_name],
+        )
     if evaluation_run.append:
         # Check that the current experiment, if one exists, has the same type (examples of traces)
         check_experiment_type(


### PR DESCRIPTION
## 📝 Summary

<!-- Add your list of changes, make it a list to improve the PR reviewers' experience. Ie:
- [ ] 1. Remove duplicate filter table
- [ ] 2. Reenabled filtering on new ExperimentRunsTableClient component, reapplied filtering changes
- [ ] 3. Added only search and filter when enter is pressed or apply filter is pressed
- [ ] 4. Error message for applying incomplete filters
- [ ] 5. Deletion should now work again for table
- [ ] 6. Comparison should now work again for table
-->
- [ ] 1. Fix issue with overriding early returning for early result

## 🎥 Demo of Changes

<!-- Add a short 1-3 minute video describing/demoing the changes -->

## ✅ Checklist

- [ ] Tagged Linear ticket in PR title. Ie. PR Title (JUD-XXXX)
- [ ] Video demo of changes
- [ ] Reviewers assigned
- [ ] Docs updated ([if necessary](https://github.com/JudgmentLabs/docs))
- [ ] Cookbooks updated ([if necessary](https://github.com/JudgmentLabs/judgment-cookbook))
