### PR TITLE
Generator wrapper (JUD-1719)

### DIFF
--- a/src/judgeval/common/api/json_encoder.py
+++ b/src/judgeval/common/api/json_encoder.py
@@ -84,7 +84,7 @@ def json_encoder(
         )
 
     # Sequences
-    if isinstance(obj, (list, set, frozenset, GeneratorType, tuple, deque)):
+    if isinstance(obj, (list, set, frozenset, tuple, deque)):
         return _dump_sequence(
             obj=obj,
         )
@@ -169,16 +169,15 @@ def _dump_other(
     obj: Any,
 ) -> Any:
     """
-    Dump an object to a hashable object, using the same parameters as jsonable_encoder
+    Dump an object to a representation without iterating it.
+
+    Avoids calling dict(obj) which can consume iterators/generators or
+    invoke user-defined iteration protocols.
     """
     try:
-        data = dict(obj)
-    except Exception:
         return repr(obj)
-
-    return json_encoder(
-        data,
-    )
+    except Exception:
+        return str(obj)
 
 
 def iso_format(o: Union[datetime.date, datetime.time]) -> str:
@@ -218,7 +217,7 @@ ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
     Enum: lambda o: o.value,
     frozenset: list,
     deque: list,
-    GeneratorType: list,
+    GeneratorType: repr,
     Path: str,
     Pattern: lambda o: o.pattern,
     SecretBytes: str,


### PR DESCRIPTION
## 📝 Summary

<!-- Add your list of changes, make it a list to improve the PR reviewers' experience. Ie:
- [ ] 1. Remove duplicate filter table
- [ ] 2. Reenabled filtering on new ExperimentRunsTableClient component, reapplied filtering changes
- [ ] 3. Added only search and filter when enter is pressed or apply filter is pressed
- [ ] 4. Error message for applying incomplete filters
- [ ] 5. Deletion should now work again for table
- [ ] 6. Comparison should now work again for table
-->
- [ ] 1. Add wrapper for generator and async generator, yield create new spans

## ✅ Checklist

- [ ] Docs updated ([if necessary](https://github.com/JudgmentLabs/docs))
- [ ] Changelogs are updated ([if necessary](https://github.com/JudgmentLabs/docs/tree/main/content/docs/changelog/%28weekly%29))
