### PR TITLE
fix api_generator and pending trace evals

### DIFF
--- a/scripts/api_generator.py
+++ b/scripts/api_generator.py
@@ -253,7 +253,7 @@ def generate_client_class(
 
 def generate_api_file() -> str:
     lines = [
-        "from typing import List, Dict, Any, Mapping, Literal, Optional",
+        "from typing import Dict, Any, Mapping, Literal, Optional",
         "import httpx",
         "from httpx import Response",
         "from judgeval.exceptions import JudgmentAPIError",

--- a/src/judgeval/tracer/__init__.py
+++ b/src/judgeval/tracer/__init__.py
@@ -484,10 +484,10 @@ class Tracer:
                         safe_serialize(format_inputs(f, args, kwargs)),
                     )
 
+                    self.judgment_processor.emit_partial()
+
                     if scorer_config:
                         self._set_pending_trace_eval(span, scorer_config, args, kwargs)
-
-                    self.judgment_processor.emit_partial()
 
                     result = f(*args, **kwargs)
                 except Exception as user_exc:
@@ -536,12 +536,12 @@ class Tracer:
                         safe_serialize(format_inputs(f, args, kwargs)),
                     )
 
+                    self.judgment_processor.emit_partial()
+
                     if scorer_config:
                         self._set_pending_trace_eval(
                             main_span, scorer_config, args, kwargs
                         )
-
-                    self.judgment_processor.emit_partial()
 
                     generator = f(*args, **kwargs)
                     set_span_attribute(
@@ -586,10 +586,10 @@ class Tracer:
                         safe_serialize(format_inputs(f, args, kwargs)),
                     )
 
+                    self.judgment_processor.emit_partial()
+
                     if scorer_config:
                         self._set_pending_trace_eval(span, scorer_config, args, kwargs)
-
-                    self.judgment_processor.emit_partial()
 
                     result = await f(*args, **kwargs)
                 except Exception as user_exc:
@@ -638,12 +638,12 @@ class Tracer:
                         safe_serialize(format_inputs(f, args, kwargs)),
                     )
 
+                    self.judgment_processor.emit_partial()
+
                     if scorer_config:
                         self._set_pending_trace_eval(
                             main_span, scorer_config, args, kwargs
                         )
-
-                    self.judgment_processor.emit_partial()
 
                     async_generator = f(*args, **kwargs)
                     set_span_attribute(


### PR DESCRIPTION
## 📝 Summary

<!-- Add your list of changes, make it a list to improve the PR reviewers' experience. Ie:
- [ ] 1. Remove duplicate filter table
- [ ] 2. Reenabled filtering on new ExperimentRunsTableClient component, reapplied filtering changes
- [ ] 3. Added only search and filter when enter is pressed or apply filter is pressed
- [ ] 4. Error message for applying incomplete filters
- [ ] 5. Deletion should now work again for table
- [ ] 6. Comparison should now work again for table
-->
- [ ] 1. move set_pending_trace_eval to after first partial emit
- [ ] 2. remove List from generate_api_file

## ✅ Checklist

- [ ] Docs updated ([if necessary](https://github.com/JudgmentLabs/docs))
- [ ] Changelogs are updated ([if necessary](https://github.com/JudgmentLabs/docs/tree/main/content/docs/changelog/%28weekly%29))
