### PR TITLE
fix: singleton meta type hint

### DIFF
--- a/src/judgeval/utils/meta.py
+++ b/src/judgeval/utils/meta.py
@@ -11,7 +11,7 @@ class SingletonMeta(type):
 
     _instances: Dict[type, object] = {}
 
-    def __call__(cls, *args, **kwargs) -> object:
+    def __call__(cls, *args, **kwargs):
         if cls not in SingletonMeta._instances:
             SingletonMeta._instances[cls] = super(SingletonMeta, cls).__call__(
                 *args, **kwargs


### PR DESCRIPTION
previously creating a tracer gets hinted as type `object`, this removes that overridden type