### PR TITLE
Fix orjson pr with non-str keys

### DIFF
--- a/src/judgeval/utils/serialize.py
+++ b/src/judgeval/utils/serialize.py
@@ -247,7 +247,10 @@ encoders_by_class_tuples = generate_encoders_by_class_tuples(ENCODERS_BY_TYPE)
 # Seralize arbitrary object to a json string
 def safe_serialize(obj: Any) -> str:
     try:
-        return orjson.dumps(json_encoder(obj)).decode()
+        return orjson.dumps(
+            json_encoder(obj),
+            option=orjson.OPT_NON_STR_KEYS
+        ).decode()
     except Exception as e:
         judgeval_logger.warning(f"Error serializing object: {e}")
-        return orjson.dumps(repr(obj)).decode()
+        return orjson.dumps(repr(obj), option=orjson.OPT_NON_STR_KEYS).decode()


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-d33b8722-b848-4d68-9967-92b38e12ecd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d33b8722-b848-4d68-9967-92b38e12ecd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

