### PR TITLE
feat: add MiniMax provider instrumentation

### DIFF
--- a/src/judgeval/instrumentation/llm/config.py
+++ b/src/judgeval/instrumentation/llm/config.py
@@ -8,6 +8,8 @@ from judgeval.instrumentation.llm.providers import (
     HAS_TOGETHER,
     HAS_ANTHROPIC,
     HAS_GOOGLE_GENAI,
+    HAS_MINIMAX,
+    is_minimax_client,
     ApiClient,
 )
 
@@ -15,6 +17,10 @@ T = TypeVar("T", bound=ApiClient)
 
 
 def _detect_provider(client: ApiClient) -> ProviderType:
+    # MiniMax must be checked before OpenAI because MiniMax clients are OpenAI instances
+    if HAS_MINIMAX and is_minimax_client(client):
+        return ProviderType.MINIMAX
+
     if HAS_OPENAI:
         from openai import OpenAI, AsyncOpenAI
 
@@ -50,12 +56,16 @@ def _detect_provider(client: ApiClient) -> ProviderType:
 def wrap_provider(client: T) -> T:
     """
     Wraps an API client to add tracing capabilities.
-    Supports OpenAI, Together, Anthropic, and Google GenAI clients.
+    Supports OpenAI, Together, Anthropic, Google GenAI, and MiniMax clients.
     Uses the active tracer via JudgmentTracerProvider.
     """
     provider_type = _detect_provider(client)
 
-    if provider_type == ProviderType.OPENAI:
+    if provider_type == ProviderType.MINIMAX:
+        from .llm_minimax.wrapper import wrap_minimax_client
+
+        return cast(T, wrap_minimax_client(client))
+    elif provider_type == ProviderType.OPENAI:
         from .llm_openai.wrapper import wrap_openai_client
 
         return cast(T, wrap_openai_client(client))

--- a/src/judgeval/instrumentation/llm/constants.py
+++ b/src/judgeval/instrumentation/llm/constants.py
@@ -8,4 +8,5 @@ class ProviderType(Enum):
     ANTHROPIC = "anthropic"
     TOGETHER = "together"
     GOOGLE = "google"
+    MINIMAX = "minimax"
     DEFAULT = "default"

--- a/src/judgeval/instrumentation/llm/llm_minimax/__init__.py
+++ b/src/judgeval/instrumentation/llm/llm_minimax/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .wrapper import wrap_minimax_client
+
+__all__ = ["wrap_minimax_client"]

--- a/src/judgeval/instrumentation/llm/llm_minimax/chat_completions.py
+++ b/src/judgeval/instrumentation/llm/llm_minimax/chat_completions.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterator,
+    AsyncIterator,
+    Generator,
+    AsyncGenerator,
+)
+
+from opentelemetry.trace import Status, StatusCode
+from judgeval.judgment_attribute_keys import AttributeKeys
+from judgeval.utils.serialize import safe_serialize
+from judgeval.utils.wrappers import (
+    immutable_wrap_async,
+    immutable_wrap_sync,
+    mutable_wrap_sync,
+    mutable_wrap_async,
+    immutable_wrap_sync_iterator,
+    immutable_wrap_async_iterator,
+)
+from judgeval.trace import BaseTracer
+
+if TYPE_CHECKING:
+    from openai import OpenAI, AsyncOpenAI
+    from openai.types.chat import ChatCompletion, ChatCompletionChunk
+
+
+def wrap_chat_completions_create_sync(client: OpenAI) -> None:
+    original_func = client.chat.completions.create
+
+    def dispatcher(*args: Any, **kwargs: Any) -> Any:
+        extra_headers = kwargs.get("extra_headers") or {}
+        if (
+            isinstance(extra_headers, dict)
+            and extra_headers.get("X-Stainless-Raw-Response") == "stream"
+        ):
+            return original_func(*args, **kwargs)
+
+        if kwargs.get("stream", False):
+            return _wrap_streaming_sync(original_func)(*args, **kwargs)
+        return _wrap_non_streaming_sync(original_func)(*args, **kwargs)
+
+    setattr(client.chat.completions, "create", dispatcher)
+
+
+def _wrap_non_streaming_sync(
+    original_func: Callable[..., ChatCompletion],
+) -> Callable[..., ChatCompletion]:
+    def pre_hook(ctx: Dict[str, Any], *args: Any, **kwargs: Any) -> None:
+        ctx["span"] = BaseTracer.start_span(
+            "MINIMAX_API_CALL", {AttributeKeys.JUDGMENT_SPAN_KIND: "llm"}
+        )
+        ctx["span"].set_attribute(AttributeKeys.GEN_AI_PROMPT, safe_serialize(kwargs))
+        model_name = kwargs.get("model", "")
+        prefixed = f"minimax/{model_name}" if model_name else ""
+        ctx["model_name"] = prefixed
+        ctx["span"].set_attribute(AttributeKeys.JUDGMENT_LLM_MODEL_NAME, prefixed)
+
+    def post_hook(ctx: Dict[str, Any], result: ChatCompletion) -> None:
+        span = ctx.get("span")
+        if not span:
+            return
+
+        span.set_attribute(AttributeKeys.GEN_AI_COMPLETION, safe_serialize(result))
+
+        if result.usage:
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS,
+                result.usage.prompt_tokens or 0,
+            )
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS,
+                result.usage.completion_tokens or 0,
+            )
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_METADATA,
+                safe_serialize(result.usage),
+            )
+
+        span.set_attribute(AttributeKeys.JUDGMENT_LLM_MODEL_NAME, ctx["model_name"])
+
+    def error_hook(ctx: Dict[str, Any], error: Exception) -> None:
+        span = ctx.get("span")
+        if span:
+            span.record_exception(error)
+            span.set_status(Status(StatusCode.ERROR))
+
+    def finally_hook(ctx: Dict[str, Any]) -> None:
+        span = ctx.get("span")
+        if span:
+            span.end()
+
+    return immutable_wrap_sync(
+        original_func,
+        pre_hook=pre_hook,
+        post_hook=post_hook,
+        error_hook=error_hook,
+        finally_hook=finally_hook,
+    )
+
+
+def _wrap_streaming_sync(
+    original_func: Callable[..., Iterator[ChatCompletionChunk]],
+) -> Callable[..., Iterator[ChatCompletionChunk]]:
+    def pre_hook(ctx: Dict[str, Any], *args: Any, **kwargs: Any) -> None:
+        ctx["span"] = BaseTracer.start_span(
+            "MINIMAX_API_CALL", {AttributeKeys.JUDGMENT_SPAN_KIND: "llm"}
+        )
+        ctx["span"].set_attribute(AttributeKeys.GEN_AI_PROMPT, safe_serialize(kwargs))
+        model_name = kwargs.get("model", "")
+        prefixed = f"minimax/{model_name}" if model_name else ""
+        ctx["model_name"] = prefixed
+        ctx["span"].set_attribute(AttributeKeys.JUDGMENT_LLM_MODEL_NAME, prefixed)
+        ctx["accumulated_content"] = ""
+
+    def mutate_hook(
+        ctx: Dict[str, Any], result: Iterator[ChatCompletionChunk]
+    ) -> Iterator[ChatCompletionChunk]:
+        def traced_generator() -> Generator[ChatCompletionChunk, None, None]:
+            for chunk in result:
+                yield chunk
+
+        def yield_hook(inner_ctx: Dict[str, Any], chunk: ChatCompletionChunk) -> None:
+            span = ctx.get("span")
+            if not span:
+                return
+            if chunk.choices and len(chunk.choices) > 0:
+                delta = chunk.choices[0].delta
+                if delta and hasattr(delta, "content") and delta.content:
+                    ctx["accumulated_content"] = (
+                        ctx.get("accumulated_content", "") + delta.content
+                    )
+            if chunk.usage:
+                span.set_attribute(
+                    AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS,
+                    chunk.usage.prompt_tokens or 0,
+                )
+                span.set_attribute(
+                    AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS,
+                    chunk.usage.completion_tokens or 0,
+                )
+                span.set_attribute(
+                    AttributeKeys.JUDGMENT_USAGE_METADATA,
+                    safe_serialize(chunk.usage),
+                )
+
+        def post_hook_inner(inner_ctx: Dict[str, Any]) -> None:
+            span = ctx.get("span")
+            if span:
+                span.set_attribute(
+                    AttributeKeys.GEN_AI_COMPLETION,
+                    ctx.get("accumulated_content", ""),
+                )
+
+        def error_hook_inner(inner_ctx: Dict[str, Any], error: Exception) -> None:
+            span = ctx.get("span")
+            if span:
+                span.record_exception(error)
+                span.set_status(Status(StatusCode.ERROR))
+
+        def finally_hook_inner(inner_ctx: Dict[str, Any]) -> None:
+            span = ctx.get("span")
+            if span:
+                span.end()
+
+        wrapped_generator = immutable_wrap_sync_iterator(
+            traced_generator,
+            yield_hook=yield_hook,
+            post_hook=post_hook_inner,
+            error_hook=error_hook_inner,
+            finally_hook=finally_hook_inner,
+        )
+
+        return wrapped_generator()
+
+    def error_hook(ctx: Dict[str, Any], error: Exception) -> None:
+        span = ctx.get("span")
+        if span:
+            span.record_exception(error)
+            span.set_status(Status(StatusCode.ERROR))
+
+    return mutable_wrap_sync(
+        original_func,
+        pre_hook=pre_hook,
+        mutate_hook=mutate_hook,
+        error_hook=error_hook,
+    )
+
+
+def wrap_chat_completions_create_async(client: AsyncOpenAI) -> None:
+    original_func = client.chat.completions.create
+
+    async def dispatcher(*args: Any, **kwargs: Any) -> Any:
+        extra_headers = kwargs.get("extra_headers") or {}
+        if (
+            isinstance(extra_headers, dict)
+            and extra_headers.get("X-Stainless-Raw-Response") == "stream"
+        ):
+            return await original_func(*args, **kwargs)
+
+        if kwargs.get("stream", False):
+            return await _wrap_streaming_async(original_func)(*args, **kwargs)
+        return await _wrap_non_streaming_async(original_func)(*args, **kwargs)
+
+    setattr(client.chat.completions, "create", dispatcher)
+
+
+def _wrap_non_streaming_async(
+    original_func: Callable[..., Awaitable[ChatCompletion]],
+) -> Callable[..., Awaitable[ChatCompletion]]:
+    def pre_hook(ctx: Dict[str, Any], *args: Any, **kwargs: Any) -> None:
+        ctx["span"] = BaseTracer.start_span(
+            "MINIMAX_API_CALL", {AttributeKeys.JUDGMENT_SPAN_KIND: "llm"}
+        )
+        ctx["span"].set_attribute(AttributeKeys.GEN_AI_PROMPT, safe_serialize(kwargs))
+        model_name = kwargs.get("model", "")
+        prefixed = f"minimax/{model_name}" if model_name else ""
+        ctx["model_name"] = prefixed
+        ctx["span"].set_attribute(AttributeKeys.JUDGMENT_LLM_MODEL_NAME, prefixed)
+
+    def post_hook(ctx: Dict[str, Any], result: ChatCompletion) -> None:
+        span = ctx.get("span")
+        if not span:
+            return
+
+        span.set_attribute(AttributeKeys.GEN_AI_COMPLETION, safe_serialize(result))
+
+        if result.usage:
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS,
+                result.usage.prompt_tokens or 0,
+            )
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS,
+                result.usage.completion_tokens or 0,
+            )
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_METADATA,
+                safe_serialize(result.usage),
+            )
+
+        span.set_attribute(AttributeKeys.JUDGMENT_LLM_MODEL_NAME, ctx["model_name"])
+
+    def error_hook(ctx: Dict[str, Any], error: Exception) -> None:
+        span = ctx.get("span")
+        if span:
+            span.record_exception(error)
+            span.set_status(Status(StatusCode.ERROR))
+
+    def finally_hook(ctx: Dict[str, Any]) -> None:
+        span = ctx.get("span")
+        if span:
+            span.end()
+
+    return immutable_wrap_async(
+        original_func,
+        pre_hook=pre_hook,
+        post_hook=post_hook,
+        error_hook=error_hook,
+        finally_hook=finally_hook,
+    )
+
+
+def _wrap_streaming_async(
+    original_func: Callable[..., Awaitable[AsyncIterator[ChatCompletionChunk]]],
+) -> Callable[..., Awaitable[AsyncIterator[ChatCompletionChunk]]]:
+    def pre_hook(ctx: Dict[str, Any], *args: Any, **kwargs: Any) -> None:
+        ctx["span"] = BaseTracer.start_span(
+            "MINIMAX_API_CALL", {AttributeKeys.JUDGMENT_SPAN_KIND: "llm"}
+        )
+        ctx["span"].set_attribute(AttributeKeys.GEN_AI_PROMPT, safe_serialize(kwargs))
+        model_name = kwargs.get("model", "")
+        prefixed = f"minimax/{model_name}" if model_name else ""
+        ctx["model_name"] = prefixed
+        ctx["span"].set_attribute(AttributeKeys.JUDGMENT_LLM_MODEL_NAME, prefixed)
+        ctx["accumulated_content"] = ""
+
+    def mutate_hook(
+        ctx: Dict[str, Any], result: AsyncIterator[ChatCompletionChunk]
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        async def traced_generator() -> AsyncGenerator[ChatCompletionChunk, None]:
+            async for chunk in result:
+                yield chunk
+
+        def yield_hook(inner_ctx: Dict[str, Any], chunk: ChatCompletionChunk) -> None:
+            span = ctx.get("span")
+            if not span:
+                return
+            if chunk.choices and len(chunk.choices) > 0:
+                delta = chunk.choices[0].delta
+                if delta and hasattr(delta, "content") and delta.content:
+                    ctx["accumulated_content"] = (
+                        ctx.get("accumulated_content", "") + delta.content
+                    )
+            if chunk.usage:
+                span.set_attribute(
+                    AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS,
+                    chunk.usage.prompt_tokens or 0,
+                )
+                span.set_attribute(
+                    AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS,
+                    chunk.usage.completion_tokens or 0,
+                )
+                span.set_attribute(
+                    AttributeKeys.JUDGMENT_USAGE_METADATA,
+                    safe_serialize(chunk.usage),
+                )
+
+        def post_hook_inner(inner_ctx: Dict[str, Any]) -> None:
+            span = ctx.get("span")
+            if span:
+                span.set_attribute(
+                    AttributeKeys.GEN_AI_COMPLETION,
+                    ctx.get("accumulated_content", ""),
+                )
+
+        def error_hook_inner(inner_ctx: Dict[str, Any], error: Exception) -> None:
+            span = ctx.get("span")
+            if span:
+                span.record_exception(error)
+                span.set_status(Status(StatusCode.ERROR))
+
+        def finally_hook_inner(inner_ctx: Dict[str, Any]) -> None:
+            span = ctx.get("span")
+            if span:
+                span.end()
+
+        wrapped_generator = immutable_wrap_async_iterator(
+            traced_generator,
+            yield_hook=yield_hook,
+            post_hook=post_hook_inner,
+            error_hook=error_hook_inner,
+            finally_hook=finally_hook_inner,
+        )
+
+        return wrapped_generator()
+
+    def error_hook(ctx: Dict[str, Any], error: Exception) -> None:
+        span = ctx.get("span")
+        if span:
+            span.record_exception(error)
+            span.set_status(Status(StatusCode.ERROR))
+
+    return mutable_wrap_async(
+        original_func,
+        pre_hook=pre_hook,
+        mutate_hook=mutate_hook,
+        error_hook=error_hook,
+    )

--- a/src/judgeval/instrumentation/llm/llm_minimax/config.py
+++ b/src/judgeval/instrumentation/llm/llm_minimax/config.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+import importlib.util
+
+HAS_MINIMAX = importlib.util.find_spec("openai") is not None
+
+MINIMAX_BASE_URL_PATTERN = "api.minimax.io"
+
+
+def is_minimax_client(client: object) -> bool:
+    """Return True if the client is an OpenAI-compatible client pointed at MiniMax."""
+    if not HAS_MINIMAX:
+        return False
+    try:
+        base_url = str(getattr(client, "base_url", ""))
+        return MINIMAX_BASE_URL_PATTERN in base_url
+    except Exception:
+        return False
+
+
+__all__ = ["HAS_MINIMAX", "is_minimax_client"]

--- a/src/judgeval/instrumentation/llm/llm_minimax/wrapper.py
+++ b/src/judgeval/instrumentation/llm/llm_minimax/wrapper.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING, Union
+import typing
+
+from judgeval.instrumentation.llm.llm_minimax.chat_completions import (
+    wrap_chat_completions_create_sync,
+    wrap_chat_completions_create_async,
+)
+
+if TYPE_CHECKING:
+    from openai import OpenAI, AsyncOpenAI
+
+    TClient = Union[OpenAI, AsyncOpenAI]
+
+
+def wrap_minimax_client_sync(client: OpenAI) -> OpenAI:
+    wrap_chat_completions_create_sync(client)
+    return client
+
+
+def wrap_minimax_client_async(client: AsyncOpenAI) -> AsyncOpenAI:
+    wrap_chat_completions_create_async(client)
+    return client
+
+
+@typing.overload
+def wrap_minimax_client(client: OpenAI) -> OpenAI: ...
+@typing.overload
+def wrap_minimax_client(  # type: ignore[overload-cannot-match]
+    client: AsyncOpenAI,
+) -> AsyncOpenAI: ...
+
+
+def wrap_minimax_client(client: TClient) -> TClient:
+    from judgeval.instrumentation.llm.llm_minimax.config import HAS_MINIMAX
+    from judgeval.logger import judgeval_logger
+
+    if not HAS_MINIMAX:
+        judgeval_logger.error(
+            "Cannot wrap MiniMax client: 'openai' library not installed. "
+            "Install it with: pip install openai"
+        )
+        return client
+
+    from openai import OpenAI, AsyncOpenAI
+
+    if isinstance(client, AsyncOpenAI):
+        return wrap_minimax_client_async(client)
+    elif isinstance(client, OpenAI):
+        return wrap_minimax_client_sync(client)
+    else:
+        raise TypeError(f"Invalid client type: {type(client)}")

--- a/src/judgeval/instrumentation/llm/providers.py
+++ b/src/judgeval/instrumentation/llm/providers.py
@@ -5,6 +5,7 @@ from judgeval.instrumentation.llm.llm_openai.config import HAS_OPENAI
 from judgeval.instrumentation.llm.llm_together.config import HAS_TOGETHER
 from judgeval.instrumentation.llm.llm_anthropic.config import HAS_ANTHROPIC
 from judgeval.instrumentation.llm.llm_google.config import HAS_GOOGLE_GENAI
+from judgeval.instrumentation.llm.llm_minimax.config import HAS_MINIMAX, is_minimax_client
 
 # TODO: if we support dependency groups we can have this better type, but during runtime, we do
 # not know which clients an end user might have installed.
@@ -16,4 +17,6 @@ __all__ = [
     "HAS_TOGETHER",
     "HAS_ANTHROPIC",
     "HAS_GOOGLE_GENAI",
+    "HAS_MINIMAX",
+    "is_minimax_client",
 ]

--- a/src/tests/instrumentation/llm/minimax/conftest.py
+++ b/src/tests/instrumentation/llm/minimax/conftest.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+from openai import OpenAI, AsyncOpenAI
+
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
+
+@pytest.fixture
+def sync_minimax_client():
+    return OpenAI(api_key="test-minimax-key", base_url=MINIMAX_BASE_URL)
+
+
+@pytest.fixture
+def async_minimax_client():
+    return AsyncOpenAI(api_key="test-minimax-key", base_url=MINIMAX_BASE_URL)
+
+
+def make_minimax_response(
+    model="MiniMax-M2.7",
+    content="Hello from MiniMax",
+    prompt_tokens=10,
+    completion_tokens=5,
+):
+    response = MagicMock()
+    response.model = model
+    response.choices = [MagicMock(message=MagicMock(content=content))]
+    response.usage = MagicMock(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+    return response

--- a/src/tests/instrumentation/llm/minimax/test_chat_completions.py
+++ b/src/tests/instrumentation/llm/minimax/test_chat_completions.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, AsyncMock
+import pytest
+
+from judgeval.judgment_attribute_keys import AttributeKeys
+from judgeval.instrumentation.llm.llm_minimax.chat_completions import (
+    wrap_chat_completions_create_sync,
+    wrap_chat_completions_create_async,
+)
+from judgeval.instrumentation.llm.llm_minimax.config import is_minimax_client
+from judgeval.instrumentation.llm.config import _detect_provider
+from judgeval.instrumentation.llm.constants import ProviderType
+from tests.instrumentation.llm.minimax.conftest import make_minimax_response
+
+
+class TestIsMinimaxClient:
+    def test_openai_client_with_minimax_base_url(self):
+        from openai import OpenAI
+
+        client = OpenAI(api_key="test", base_url="https://api.minimax.io/v1")
+        assert is_minimax_client(client) is True
+
+    def test_openai_client_without_minimax_base_url(self):
+        from openai import OpenAI
+
+        client = OpenAI(api_key="test", base_url="https://api.openai.com/v1")
+        assert is_minimax_client(client) is False
+
+    def test_non_client_object(self):
+        assert is_minimax_client(object()) is False
+
+
+class TestDetectProvider:
+    def test_detects_minimax_from_openai_client(self):
+        from openai import OpenAI
+
+        client = OpenAI(api_key="test", base_url="https://api.minimax.io/v1")
+        result = _detect_provider(client)
+        assert result == ProviderType.MINIMAX
+
+    def test_regular_openai_client_is_not_minimax(self):
+        from openai import OpenAI
+
+        client = OpenAI(api_key="test", base_url="https://api.openai.com/v1")
+        result = _detect_provider(client)
+        assert result == ProviderType.OPENAI
+
+
+class TestSyncNonStreaming:
+    def test_creates_span(self, tracer, collecting_exporter, sync_minimax_client):
+        response = make_minimax_response()
+        sync_minimax_client.chat.completions.create = MagicMock(return_value=response)
+        wrap_chat_completions_create_sync(sync_minimax_client)
+        sync_minimax_client.chat.completions.create(
+            model="MiniMax-M2.7", messages=[]
+        )
+        assert any(s.name == "MINIMAX_API_CALL" for s in collecting_exporter.spans)
+
+    def test_span_has_llm_kind(self, tracer, collecting_exporter, sync_minimax_client):
+        response = make_minimax_response()
+        sync_minimax_client.chat.completions.create = MagicMock(return_value=response)
+        wrap_chat_completions_create_sync(sync_minimax_client)
+        sync_minimax_client.chat.completions.create(
+            model="MiniMax-M2.7", messages=[]
+        )
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "MINIMAX_API_CALL"
+        )
+        assert span.attributes.get(AttributeKeys.JUDGMENT_SPAN_KIND) == "llm"
+
+    def test_model_name_has_minimax_prefix(
+        self, tracer, collecting_exporter, sync_minimax_client
+    ):
+        response = make_minimax_response()
+        sync_minimax_client.chat.completions.create = MagicMock(return_value=response)
+        wrap_chat_completions_create_sync(sync_minimax_client)
+        sync_minimax_client.chat.completions.create(
+            model="MiniMax-M2.7", messages=[]
+        )
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "MINIMAX_API_CALL"
+        )
+        assert (
+            span.attributes.get(AttributeKeys.JUDGMENT_LLM_MODEL_NAME)
+            == "minimax/MiniMax-M2.7"
+        )
+
+    def test_records_token_usage(
+        self, tracer, collecting_exporter, sync_minimax_client
+    ):
+        response = make_minimax_response(prompt_tokens=20, completion_tokens=10)
+        sync_minimax_client.chat.completions.create = MagicMock(return_value=response)
+        wrap_chat_completions_create_sync(sync_minimax_client)
+        sync_minimax_client.chat.completions.create(
+            model="MiniMax-M2.7", messages=[]
+        )
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "MINIMAX_API_CALL"
+        )
+        assert (
+            span.attributes.get(AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS)
+            == 20
+        )
+        assert span.attributes.get(AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS) == 10
+
+    def test_error_sets_error_status(
+        self, tracer, collecting_exporter, sync_minimax_client
+    ):
+        sync_minimax_client.chat.completions.create = MagicMock(
+            side_effect=RuntimeError("api error")
+        )
+        wrap_chat_completions_create_sync(sync_minimax_client)
+        with pytest.raises(RuntimeError):
+            sync_minimax_client.chat.completions.create(
+                model="MiniMax-M2.7", messages=[]
+            )
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "MINIMAX_API_CALL"
+        )
+        assert span.status.status_code.name == "ERROR"
+
+    def test_returns_result(self, tracer, sync_minimax_client):
+        response = make_minimax_response()
+        sync_minimax_client.chat.completions.create = MagicMock(return_value=response)
+        wrap_chat_completions_create_sync(sync_minimax_client)
+        result = sync_minimax_client.chat.completions.create(
+            model="MiniMax-M2.7", messages=[]
+        )
+        assert result is response
+
+
+class TestAsyncNonStreaming:
+    @pytest.mark.asyncio
+    async def test_creates_span(
+        self, tracer, collecting_exporter, async_minimax_client
+    ):
+        response = make_minimax_response()
+        async_minimax_client.chat.completions.create = AsyncMock(return_value=response)
+        wrap_chat_completions_create_async(async_minimax_client)
+        await async_minimax_client.chat.completions.create(
+            model="MiniMax-M2.7", messages=[]
+        )
+        assert any(s.name == "MINIMAX_API_CALL" for s in collecting_exporter.spans)
+
+    @pytest.mark.asyncio
+    async def test_model_name_has_minimax_prefix(
+        self, tracer, collecting_exporter, async_minimax_client
+    ):
+        response = make_minimax_response()
+        async_minimax_client.chat.completions.create = AsyncMock(return_value=response)
+        wrap_chat_completions_create_async(async_minimax_client)
+        await async_minimax_client.chat.completions.create(
+            model="MiniMax-M2.7-highspeed", messages=[]
+        )
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "MINIMAX_API_CALL"
+        )
+        assert (
+            span.attributes.get(AttributeKeys.JUDGMENT_LLM_MODEL_NAME)
+            == "minimax/MiniMax-M2.7-highspeed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_records_token_usage(
+        self, tracer, collecting_exporter, async_minimax_client
+    ):
+        response = make_minimax_response(prompt_tokens=15, completion_tokens=8)
+        async_minimax_client.chat.completions.create = AsyncMock(return_value=response)
+        wrap_chat_completions_create_async(async_minimax_client)
+        await async_minimax_client.chat.completions.create(
+            model="MiniMax-M2.7", messages=[]
+        )
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "MINIMAX_API_CALL"
+        )
+        assert (
+            span.attributes.get(AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS)
+            == 15
+        )
+        assert span.attributes.get(AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS) == 8


### PR DESCRIPTION
## Summary

- Adds MiniMax chat model provider instrumentation using the OpenAI-compatible API (`api.minimax.io`)
- Detects MiniMax clients by inspecting the `base_url` of an OpenAI client before falling through to the standard OpenAI path
- Introduces `ProviderType.MINIMAX` and tags all spans as `MINIMAX_API_CALL` with model names prefixed as `minimax/<model>`
- Supports sync/async clients and both streaming and non-streaming calls
- Adds 14 unit tests covering: client detection, span creation, span kind, model name prefix, token usage, error handling, and return value passthrough

## Usage

```python
from openai import OpenAI
from judgeval import Tracer, wrap

Tracer.init(project_name="my-project")

client = wrap(OpenAI(
    api_key="MINIMAX_API_KEY",
    base_url="https://api.minimax.io/v1",
))

response = client.chat.completions.create(
    model="MiniMax-M2.7",
    messages=[{"role": "user", "content": "Hello!"}],
    temperature=1.0,
)
```

Spans will appear in your Judgment dashboard tagged as `MINIMAX_API_CALL` with model `minimax/MiniMax-M2.7`.

## Supported models

| Model ID | Description |
|----------|-------------|
| `MiniMax-M2.7` | Peak Performance. Ultimate Value. |
| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile |

## API reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval/pull/735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
