### PR TITLE
JUD-7824 feat(trace): public set_propagating_attribute for trace-wide attributes

### DIFF
--- a/src/judgeval/trace/base_tracer.py
+++ b/src/judgeval/trace/base_tracer.py
@@ -1172,6 +1172,7 @@ class BaseTracer(ABC):
         )
 
     @staticmethod
+    @dont_throw
     def set_propagating_attribute(key: str, value: str) -> None:
         """Set an attribute and propagate it to all child spans via baggage.
 

--- a/src/judgeval/trace/base_tracer.py
+++ b/src/judgeval/trace/base_tracer.py
@@ -1171,6 +1171,41 @@ class BaseTracer(ABC):
             AttributeKeys.JUDGMENT_SESSION_ID.value, session_id
         )
 
+    @staticmethod
+    def set_propagating_attribute(key: str, value: str) -> None:
+        """Set an arbitrary attribute and propagate it to all child spans.
+
+        Unlike :meth:`set_attribute`, which applies only to a single span,
+        the value set here follows the whole trace via baggage — every
+        descendant span receives it as an attribute. Use this to tag a trace
+        with a dimension you want to filter on in Views (e.g. the surface an
+        agent is running on).
+
+        The ``judgment.`` namespace is reserved for SDK-managed keys (customer
+        ID, session ID, etc.); use :meth:`set_customer_id` / :meth:`set_session_id`
+        for those instead.
+
+        Args:
+            key: The attribute key. Must not use the reserved ``judgment.``
+                prefix.
+            value: The attribute value.
+
+        Examples:
+            ```python
+            @Tracer.observe(span_type="agent")
+            def handle_message(message: str):
+                Tracer.set_propagating_attribute("luna.surface", "slack")
+                return agent.respond(message)
+            ```
+        """
+        if key.startswith("judgment."):
+            judgeval_logger.warning(
+                f'set_propagating_attribute: key "{key}" uses the reserved '
+                '"judgment." prefix; ignoring'
+            )
+            return
+        BaseTracer._set_propagating_baggage_key(key, value)
+
     # ------------------------------------------------------------------ #
     #  Static: Tags                                                      #
     # ------------------------------------------------------------------ #

--- a/src/judgeval/trace/base_tracer.py
+++ b/src/judgeval/trace/base_tracer.py
@@ -1175,7 +1175,7 @@ class BaseTracer(ABC):
     def set_propagating_attribute(key: str, value: str) -> None:
         """Set an attribute and propagate it to all child spans via baggage.
 
-        Unlike :meth:`set_attribute` (single span only). The ``judgment.``
+        Unlike ``set_attribute`` (single span only). The ``judgment.``
         prefix is reserved and ignored.
         """
         if key.startswith("judgment."):

--- a/src/judgeval/trace/base_tracer.py
+++ b/src/judgeval/trace/base_tracer.py
@@ -1173,30 +1173,10 @@ class BaseTracer(ABC):
 
     @staticmethod
     def set_propagating_attribute(key: str, value: str) -> None:
-        """Set an arbitrary attribute and propagate it to all child spans.
+        """Set an attribute and propagate it to all child spans via baggage.
 
-        Unlike :meth:`set_attribute`, which applies only to a single span,
-        the value set here follows the whole trace via baggage — every
-        descendant span receives it as an attribute. Use this to tag a trace
-        with a dimension you want to filter on in Views (e.g. the surface an
-        agent is running on).
-
-        The ``judgment.`` namespace is reserved for SDK-managed keys (customer
-        ID, session ID, etc.); use :meth:`set_customer_id` / :meth:`set_session_id`
-        for those instead.
-
-        Args:
-            key: The attribute key. Must not use the reserved ``judgment.``
-                prefix.
-            value: The attribute value.
-
-        Examples:
-            ```python
-            @Tracer.observe(span_type="agent")
-            def handle_message(message: str):
-                Tracer.set_propagating_attribute("luna.surface", "slack")
-                return agent.respond(message)
-            ```
+        Unlike :meth:`set_attribute` (single span only). The ``judgment.``
+        prefix is reserved and ignored.
         """
         if key.startswith("judgment."):
             judgeval_logger.warning(

--- a/src/tests/trace/test_base_tracer.py
+++ b/src/tests/trace/test_base_tracer.py
@@ -132,6 +132,36 @@ class TestContextPropagation:
     def test_set_propagating_baggage_key_noop_outside_span(self, tracer):
         BaseTracer._set_propagating_baggage_key("some.key", "val")
 
+    def test_set_propagating_attribute_on_span(self, tracer, collecting_exporter):
+        with BaseTracer.start_as_current_span("surface"):
+            BaseTracer.set_propagating_attribute("luna.surface", "slack")
+        span = next(s for s in collecting_exporter.spans if s.name == "surface")
+        assert span.attributes["luna.surface"] == "slack"
+
+    def test_set_propagating_attribute_propagates_to_child(
+        self, tracer, collecting_exporter
+    ):
+        with BaseTracer.start_as_current_span("root"):
+            BaseTracer.set_propagating_attribute("luna.surface", "platform")
+            with BaseTracer.start_as_current_span("child"):
+                pass
+        child = next(s for s in collecting_exporter.spans if s.name == "child")
+        assert child.attributes.get("luna.surface") == "platform"
+
+    def test_set_propagating_attribute_rejects_reserved_prefix(
+        self, tracer, collecting_exporter
+    ):
+        from judgeval.logger import judgeval_logger
+
+        with patch.object(judgeval_logger, "warning") as warning_mock:
+            with BaseTracer.start_as_current_span("reserved"):
+                BaseTracer.set_propagating_attribute(
+                    AttributeKeys.JUDGMENT_CUSTOMER_ID.value, "evil"
+                )
+        span = next(s for s in collecting_exporter.spans if s.name == "reserved")
+        assert AttributeKeys.JUDGMENT_CUSTOMER_ID not in span.attributes
+        warning_mock.assert_called_once()
+
 
 class TestScopedContext:
     def test_sets_attributes_on_spans_created_inside_scope(


### PR DESCRIPTION
## What
Adds `Tracer.set_propagating_attribute(key, value)` — a public wrapper over the existing private `_set_propagating_baggage_key` helper. The value is set on the current span **and** written to OTel baggage, so it propagates to every child span (via `JudgmentBaggageProcessor`), exactly like `set_customer_id` / `set_session_id`.

Unlike `set_attribute` (single-span only), this follows the whole trace — so a trace can be tagged with a dimension you filter on in Views (e.g. the surface an agent runs on).

Guards the reserved `judgment.` namespace to avoid clobbering SDK-managed keys.

## Why
Closes the gap raised in the Slack tracing thread: teams want to propagate an *arbitrary* attribute across all spans (not just the three fixed keys). The baggage machinery already supported it (`ALLOW_ALL_BAGGAGE_KEYS` predicate); only a public entry point was missing.

## Tests
`TestContextPropagation`: sets-on-span, propagates-to-child, rejects-reserved-prefix. `pytest` + `ruff` green.

## Follow-ups (separate PRs)
- judgeval-js: same method (parity)
- luna harness + judgment-mono: use it for `luna.surface` (Slack vs platform) — **those depend on this being published**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval/pull/753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

> Retargeted base to `staging` per the repo branch-protection policy (PRs to `main` come from `staging`).
