### PR TITLE
fix(instrumentation): handle MessageDeltaUsage in Anthropic streaming token extraction

### DIFF
--- a/src/judgeval/instrumentation/llm/llm_anthropic/messages.py
+++ b/src/judgeval/instrumentation/llm/llm_anthropic/messages.py
@@ -45,19 +45,17 @@ def _extract_anthropic_content(chunk: RawMessageStreamEvent) -> str:
 
 def _extract_anthropic_tokens(
     usage: Usage | MessageDeltaUsage,
-) -> Tuple[int, int, int, int]:
-    input_tokens = usage.input_tokens if usage.input_tokens is not None else 0
-    output_tokens = usage.output_tokens if usage.output_tokens is not None else 0
-    cache_read = (
-        usage.cache_read_input_tokens
-        if usage.cache_read_input_tokens is not None
-        else 0
-    )
-    cache_creation = (
-        usage.cache_creation_input_tokens
-        if usage.cache_creation_input_tokens is not None
-        else 0
-    )
+) -> Tuple[int | None, int | None, int | None, int | None]:
+    """Extract token counts from a Usage or MessageDeltaUsage object.
+
+    Returns None for fields absent on the object (e.g. MessageDeltaUsage only
+    carries output_tokens; all other fields are absent, not zero). Callers
+    that need a guaranteed int should apply ``or 0`` at the call site.
+    """
+    input_tokens = getattr(usage, "input_tokens", None)
+    output_tokens = getattr(usage, "output_tokens", None)
+    cache_read = getattr(usage, "cache_read_input_tokens", None)
+    cache_creation = getattr(usage, "cache_creation_input_tokens", None)
     return (input_tokens, output_tokens, cache_read, cache_creation)
 
 
@@ -69,6 +67,34 @@ def _extract_anthropic_chunk_usage(
     elif chunk.type == "message_delta":
         return chunk.usage if hasattr(chunk, "usage") else None
     return None
+
+
+def _apply_usage_to_span(span: Any, usage: Usage | MessageDeltaUsage) -> None:
+    """Write only the token fields present on *usage* to the span.
+
+    This is called from the streaming yield_hook for both message_start
+    (full Usage) and message_delta (MessageDeltaUsage, output_tokens only).
+    Skipping None values ensures a message_delta never zeroes out the
+    input_tokens that message_start already recorded.
+    """
+    input_tokens, output_tokens, cache_read, cache_creation = (
+        _extract_anthropic_tokens(usage)
+    )
+    if input_tokens is not None:
+        span.set_attribute(
+            AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS, input_tokens
+        )
+    if output_tokens is not None:
+        span.set_attribute(AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS, output_tokens)
+    if cache_read is not None:
+        span.set_attribute(
+            AttributeKeys.JUDGMENT_USAGE_CACHE_READ_INPUT_TOKENS, cache_read
+        )
+    if cache_creation is not None:
+        span.set_attribute(
+            AttributeKeys.JUDGMENT_USAGE_CACHE_CREATION_INPUT_TOKENS, cache_creation
+        )
+    span.set_attribute(AttributeKeys.JUDGMENT_USAGE_METADATA, safe_serialize(usage))
 
 
 def wrap_messages_create_sync(client: Anthropic) -> None:
@@ -108,17 +134,17 @@ def _wrap_non_streaming_sync(
             )
             span.set_attribute(
                 AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS,
-                prompt_tokens,
+                prompt_tokens or 0,
             )
             span.set_attribute(
-                AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS, completion_tokens
+                AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS, completion_tokens or 0
             )
             span.set_attribute(
-                AttributeKeys.JUDGMENT_USAGE_CACHE_READ_INPUT_TOKENS, cache_read
+                AttributeKeys.JUDGMENT_USAGE_CACHE_READ_INPUT_TOKENS, cache_read or 0
             )
             span.set_attribute(
                 AttributeKeys.JUDGMENT_USAGE_CACHE_CREATION_INPUT_TOKENS,
-                cache_creation,
+                cache_creation or 0,
             )
             span.set_attribute(
                 AttributeKeys.JUDGMENT_USAGE_METADATA,
@@ -181,25 +207,7 @@ def _wrap_streaming_sync(
 
             usage_data = _extract_anthropic_chunk_usage(chunk)
             if usage_data:
-                prompt_tokens, completion_tokens, cache_read, cache_creation = (
-                    _extract_anthropic_tokens(usage_data)
-                )
-                span.set_attribute(
-                    AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS, prompt_tokens
-                )
-                span.set_attribute(
-                    AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS, completion_tokens
-                )
-                span.set_attribute(
-                    AttributeKeys.JUDGMENT_USAGE_CACHE_READ_INPUT_TOKENS, cache_read
-                )
-                span.set_attribute(
-                    AttributeKeys.JUDGMENT_USAGE_CACHE_CREATION_INPUT_TOKENS,
-                    cache_creation,
-                )
-                span.set_attribute(
-                    AttributeKeys.JUDGMENT_USAGE_METADATA, safe_serialize(usage_data)
-                )
+                _apply_usage_to_span(span, usage_data)
 
         def post_hook_inner(inner_ctx: Dict[str, Any]) -> None:
             span = ctx.get("span")
@@ -279,17 +287,17 @@ def _wrap_non_streaming_async(
             )
             span.set_attribute(
                 AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS,
-                prompt_tokens,
+                prompt_tokens or 0,
             )
             span.set_attribute(
-                AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS, completion_tokens
+                AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS, completion_tokens or 0
             )
             span.set_attribute(
-                AttributeKeys.JUDGMENT_USAGE_CACHE_READ_INPUT_TOKENS, cache_read
+                AttributeKeys.JUDGMENT_USAGE_CACHE_READ_INPUT_TOKENS, cache_read or 0
             )
             span.set_attribute(
                 AttributeKeys.JUDGMENT_USAGE_CACHE_CREATION_INPUT_TOKENS,
-                cache_creation,
+                cache_creation or 0,
             )
             span.set_attribute(
                 AttributeKeys.JUDGMENT_USAGE_METADATA,
@@ -352,25 +360,7 @@ def _wrap_streaming_async(
 
             usage_data = _extract_anthropic_chunk_usage(chunk)
             if usage_data:
-                prompt_tokens, completion_tokens, cache_read, cache_creation = (
-                    _extract_anthropic_tokens(usage_data)
-                )
-                span.set_attribute(
-                    AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS, prompt_tokens
-                )
-                span.set_attribute(
-                    AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS, completion_tokens
-                )
-                span.set_attribute(
-                    AttributeKeys.JUDGMENT_USAGE_CACHE_READ_INPUT_TOKENS, cache_read
-                )
-                span.set_attribute(
-                    AttributeKeys.JUDGMENT_USAGE_CACHE_CREATION_INPUT_TOKENS,
-                    cache_creation,
-                )
-                span.set_attribute(
-                    AttributeKeys.JUDGMENT_USAGE_METADATA, safe_serialize(usage_data)
-                )
+                _apply_usage_to_span(span, usage_data)
 
         def post_hook_inner(inner_ctx: Dict[str, Any]) -> None:
             span = ctx.get("span")

--- a/src/tests/instrumentation/llm/anthropic/conftest.py
+++ b/src/tests/instrumentation/llm/anthropic/conftest.py
@@ -31,3 +31,38 @@ def make_message(
         cache_creation_input_tokens=None,
     )
     return msg
+
+
+def make_stream_chunks(input_tokens=10, start_output_tokens=5, final_output_tokens=42):
+    """Return a list of fake RawMessageStreamEvent chunks for streaming tests.
+
+    Produces three chunks in Anthropic's streaming protocol order:
+    - message_start: carries the full Usage (input count + early output estimate)
+    - content_block_delta: carries a text fragment
+    - message_delta: carries MessageDeltaUsage with the authoritative output count
+    """
+    from unittest.mock import MagicMock
+    from anthropic.types import Usage, MessageDeltaUsage
+
+    start_chunk = MagicMock()
+    start_chunk.type = "message_start"
+    start_chunk.message = MagicMock()
+    start_chunk.message.usage = MagicMock(
+        spec=Usage,
+        input_tokens=input_tokens,
+        output_tokens=start_output_tokens,
+        cache_read_input_tokens=None,
+        cache_creation_input_tokens=None,
+    )
+
+    content_chunk = MagicMock()
+    content_chunk.type = "content_block_delta"
+    content_chunk.delta = MagicMock()
+    content_chunk.delta.type = "text_delta"
+    content_chunk.delta.text = "Hello"
+
+    delta_chunk = MagicMock()
+    delta_chunk.type = "message_delta"
+    delta_chunk.usage = MagicMock(spec=MessageDeltaUsage, output_tokens=final_output_tokens)
+
+    return [start_chunk, content_chunk, delta_chunk]

--- a/src/tests/instrumentation/llm/anthropic/test_messages.py
+++ b/src/tests/instrumentation/llm/anthropic/test_messages.py
@@ -8,7 +8,7 @@ from judgeval.instrumentation.llm.llm_anthropic.messages import (
     wrap_messages_create_sync,
     wrap_messages_create_async,
 )
-from tests.instrumentation.llm.anthropic.conftest import make_message
+from tests.instrumentation.llm.anthropic.conftest import make_message, make_stream_chunks
 
 
 class TestSyncNonStreaming:
@@ -108,3 +108,115 @@ class TestAsyncNonStreaming:
             s for s in collecting_exporter.spans if s.name == "ANTHROPIC_API_CALL"
         )
         assert span.status.status_code.name == "ERROR"
+
+
+class TestSyncStreaming:
+    def test_creates_span(self, tracer, collecting_exporter, sync_anthropic_client):
+        chunks = make_stream_chunks()
+        sync_anthropic_client.messages.create = MagicMock(return_value=iter(chunks))
+        wrap_messages_create_sync(sync_anthropic_client)
+        list(
+            sync_anthropic_client.messages.create(
+                model="claude-3-5-sonnet-latest",
+                messages=[],
+                max_tokens=100,
+                stream=True,
+            )
+        )
+        assert any(s.name == "ANTHROPIC_API_CALL" for s in collecting_exporter.spans)
+
+    def test_records_input_tokens_from_message_start(
+        self, tracer, collecting_exporter, sync_anthropic_client
+    ):
+        chunks = make_stream_chunks(input_tokens=15)
+        sync_anthropic_client.messages.create = MagicMock(return_value=iter(chunks))
+        wrap_messages_create_sync(sync_anthropic_client)
+        list(
+            sync_anthropic_client.messages.create(
+                model="claude-3-5-sonnet-latest",
+                messages=[],
+                max_tokens=100,
+                stream=True,
+            )
+        )
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "ANTHROPIC_API_CALL"
+        )
+        assert (
+            span.attributes.get(AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS)
+            == 15
+        )
+
+    def test_records_final_output_tokens_from_message_delta(
+        self, tracer, collecting_exporter, sync_anthropic_client
+    ):
+        # message_start carries an early output estimate (5), message_delta carries
+        # the authoritative final count (42). The span must reflect the final count.
+        chunks = make_stream_chunks(start_output_tokens=5, final_output_tokens=42)
+        sync_anthropic_client.messages.create = MagicMock(return_value=iter(chunks))
+        wrap_messages_create_sync(sync_anthropic_client)
+        list(
+            sync_anthropic_client.messages.create(
+                model="claude-3-5-sonnet-latest",
+                messages=[],
+                max_tokens=100,
+                stream=True,
+            )
+        )
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "ANTHROPIC_API_CALL"
+        )
+        assert span.attributes.get(AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS) == 42
+
+
+class TestAsyncStreaming:
+    @pytest.mark.asyncio
+    async def test_creates_span(
+        self, tracer, collecting_exporter, async_anthropic_client
+    ):
+        chunks = make_stream_chunks()
+
+        async def fake_aiter():
+            for chunk in chunks:
+                yield chunk
+
+        async_anthropic_client.messages.create = AsyncMock(
+            return_value=fake_aiter()
+        )
+        wrap_messages_create_async(async_anthropic_client)
+        stream = await async_anthropic_client.messages.create(
+            model="claude-3-5-sonnet-latest",
+            messages=[],
+            max_tokens=100,
+            stream=True,
+        )
+        async for _ in stream:
+            pass
+        assert any(s.name == "ANTHROPIC_API_CALL" for s in collecting_exporter.spans)
+
+    @pytest.mark.asyncio
+    async def test_records_final_output_tokens_from_message_delta(
+        self, tracer, collecting_exporter, async_anthropic_client
+    ):
+        chunks = make_stream_chunks(start_output_tokens=5, final_output_tokens=37)
+
+        async def fake_aiter():
+            for chunk in chunks:
+                yield chunk
+
+        async_anthropic_client.messages.create = AsyncMock(
+            return_value=fake_aiter()
+        )
+        wrap_messages_create_async(async_anthropic_client)
+        stream = await async_anthropic_client.messages.create(
+            model="claude-3-5-sonnet-latest",
+            messages=[],
+            max_tokens=100,
+            stream=True,
+        )
+        async for _ in stream:
+            pass
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "ANTHROPIC_API_CALL"
+        )
+        assert span.attributes.get(AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS) == 37


### PR DESCRIPTION
## Summary

Fixes #754 — Anthropic streaming calls recorded incorrect output token counts because `_extract_anthropic_tokens` raised `AttributeError` on `MessageDeltaUsage`, which the `dont_throw` wrapper silently swallowed.

**Root cause**

Anthropic's streaming protocol emits two usage objects across the stream lifecycle:

| Event | Type | Fields |
|---|---|---|
| `message_start` | `Usage` | `input_tokens`, `output_tokens` (early estimate), `cache_*` |
| `message_delta` | `MessageDeltaUsage` | `output_tokens` (authoritative final count) only |

`_extract_anthropic_tokens` accessed `usage.input_tokens` directly. On `MessageDeltaUsage` this raised `AttributeError`, caught silently by `dont_throw`. Result: the final output token count from `message_delta` was never written to the span — every streaming call showed the early estimate from `message_start` instead.

**Fix design**

Three targeted changes, zero behaviour change to non-streaming paths:

1. **`_extract_anthropic_tokens`** — use `getattr(usage, field, None)` for all four fields; return `int | None` so callers can distinguish "field absent" from "field is zero".

2. **`_apply_usage_to_span`** (new helper) — writes only the non-`None` fields to the span. This prevents a `message_delta` chunk from zeroing out `input_tokens` that `message_start` already recorded.

3. **Non-streaming `post_hook`** — full `Usage` is always present; callers apply `or 0` so the existing integer-attribute contract is preserved.

**Before / after for a streaming call with input=15, final output=42**

| Span attribute | Before fix | After fix |
|---|---|---|
| `JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS` | 15 ✓ | 15 ✓ |
| `JUDGMENT_USAGE_OUTPUT_TOKENS` | 5 (early estimate) ✗ | 42 (final count) ✓ |

**Tests**

Adds `TestSyncStreaming` and `TestAsyncStreaming` — the streaming code paths had **no test coverage at all** before this PR. New tests verify:
- A span is created for streaming calls
- `input_tokens` is recorded from `message_start` and not overwritten by `message_delta`
- The final `output_tokens` from `message_delta` is what the span ultimately reflects

- [x] Existing non-streaming tests still pass (12/12 green)
- [x] No dependency changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval/pull/755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->