### PR TITLE
fix: validate Example.create() property keys

### DIFF
--- a/src/judgeval/data/example.py
+++ b/src/judgeval/data/example.py
@@ -2,13 +2,24 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime
+import difflib
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from judgeval.internal.api.models import Example as APIExample
 
 if TYPE_CHECKING:
     from judgeval.data.trace import Trace
+
+_RESERVED_KEYS = frozenset({"example_id", "created_at", "name", "trace"})
+_COMMON_KEYS = (
+    "input",
+    "actual_output",
+    "expected_output",
+    "retrieval_context",
+    "context",
+    "offline_trace_id",
+)
 
 
 @dataclass(slots=True)
@@ -51,7 +62,9 @@ class Example:
     """
 
     example_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    created_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
     name: Optional[str] = None
     _properties: Dict[str, Any] = field(default_factory=dict)
     trace: Optional[Trace] = None
@@ -76,6 +89,18 @@ class Example:
         """
         example = cls()
         for key, value in kwargs.items():
+            if key in _RESERVED_KEYS:
+                raise ValueError(
+                    f"Invalid property '{key}'. Don't pass this to Example.create()."
+                )
+            if key not in _COMMON_KEYS:
+                matches = difflib.get_close_matches(
+                    key, _COMMON_KEYS, n=1, cutoff=0.75
+                )
+                if matches:
+                    raise ValueError(
+                        f"Invalid property '{key}'. Did you mean '{matches[0]}'?"
+                    )
             example._properties[key] = value
         return example
 

--- a/src/tests/datasets/test_example.py
+++ b/src/tests/datasets/test_example.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 import pytest
 
 from judgeval.data.example import Example
@@ -59,3 +61,26 @@ class TestExample:
         e = Example.create(val=1)
         e._properties["val"] = 2
         assert e["val"] == 2
+
+    @pytest.mark.parametrize(
+        "key",
+        ["example_id", "created_at", "name", "trace"],
+    )
+    def test_create_rejects_reserved_keys(self, key):
+        with pytest.raises(ValueError, match=f"Invalid property '{key}'"):
+            Example.create(**{key: "value"})
+
+    def test_create_suggests_typo_fix(self):
+        with pytest.raises(ValueError, match="Did you mean 'actual_output'"):
+            Example.create(actual_outpt="oops")
+
+    def test_create_allows_custom_keys(self):
+        e = Example.create(output="a", question="q", custom_metric=0.9)
+        assert e["output"] == "a"
+        assert e["question"] == "q"
+        assert e["custom_metric"] == 0.9
+
+    def test_create_no_deprecation_warning(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            Example()


### PR DESCRIPTION
Fixes #460

- Reject reserved keys (example_id, created_at, name, trace) in Example.create()
- Suggest typo fixes for common fields (e.g., actual_outpt → actual_output)
- Replace deprecated utcnow() with timezone-aware UTC
- 17 tests passing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval/pull/758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->