### PR TITLE
feat(google): instrument generate_content_stream for streaming spans

### DIFF
--- a/src/judgeval/instrumentation/llm/llm_google/generate_content.py
+++ b/src/judgeval/instrumentation/llm/llm_google/generate_content.py
@@ -10,7 +10,7 @@ from typing import (
 from opentelemetry.trace import Status, StatusCode
 from judgeval.judgment_attribute_keys import AttributeKeys
 from judgeval.utils.serialize import safe_serialize
-from judgeval.utils.wrappers import immutable_wrap_sync
+from judgeval.utils.wrappers import immutable_wrap_sync, immutable_wrap_sync_iterator
 from judgeval.trace import BaseTracer
 
 if TYPE_CHECKING:
@@ -119,3 +119,87 @@ def wrap_generate_content_sync(client: Client) -> None:
     )
 
     setattr(client.models, "generate_content", wrapped)
+
+
+def _process_google_stream_chunk(
+    context: Dict[str, Any],
+    chunk: GenerateContentResponse,
+) -> None:
+    if chunk.text:
+        context["accumulated_text"] = context.get("accumulated_text", "") + chunk.text
+    if chunk.usage_metadata is not None:
+        context["usage_data"] = chunk.usage_metadata
+    if hasattr(chunk, "model_version") and chunk.model_version:
+        context["model_version"] = chunk.model_version
+
+
+def wrap_generate_content_stream_sync(client: Client) -> None:
+    original_func = client.models.generate_content_stream
+
+    def pre_hook(ctx: Dict[str, Any], *args: Any, **kwargs: Any) -> None:
+        ctx["span"] = BaseTracer.start_span(
+            "GOOGLE_API_CALL", {AttributeKeys.JUDGMENT_SPAN_KIND: "llm"}
+        )
+        ctx["span"].set_attribute(AttributeKeys.GEN_AI_PROMPT, safe_serialize(kwargs))
+        ctx["model_name"] = kwargs.get("model", "")
+        ctx["span"].set_attribute(
+            AttributeKeys.JUDGMENT_LLM_MODEL_NAME, ctx["model_name"]
+        )
+
+    def yield_hook(ctx: Dict[str, Any], chunk: GenerateContentResponse) -> None:
+        _process_google_stream_chunk(ctx, chunk)
+
+    def error_hook(ctx: Dict[str, Any], error: Exception) -> None:
+        span = ctx.get("span")
+        if span:
+            span.record_exception(error)
+            span.set_status(Status(StatusCode.ERROR))
+
+    def finally_hook(ctx: Dict[str, Any]) -> None:
+        span = ctx.get("span")
+        if not span:
+            return
+
+        accumulated = ctx.get("accumulated_text", "")
+        if accumulated:
+            span.set_attribute(AttributeKeys.GEN_AI_COMPLETION, accumulated)
+
+        model_version = ctx.get("model_version") or ctx.get("model_name", "")
+        if model_version:
+            span.set_attribute(AttributeKeys.JUDGMENT_LLM_MODEL_NAME, model_version)
+
+        usage_data = ctx.get("usage_data")
+        if usage_data:
+            prompt_tokens, completion_tokens, cache_read, cache_creation = (
+                _extract_google_tokens(usage_data)
+            )
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS,
+                prompt_tokens,
+            )
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS, completion_tokens
+            )
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_CACHE_READ_INPUT_TOKENS, cache_read
+            )
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_CACHE_CREATION_INPUT_TOKENS,
+                cache_creation,
+            )
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_METADATA,
+                safe_serialize(usage_data),
+            )
+
+        span.end()
+
+    wrapped = immutable_wrap_sync_iterator(
+        original_func,
+        pre_hook=pre_hook,
+        yield_hook=yield_hook,
+        error_hook=error_hook,
+        finally_hook=finally_hook,
+    )
+
+    setattr(client.models, "generate_content_stream", wrapped)

--- a/src/judgeval/instrumentation/llm/llm_google/wrapper.py
+++ b/src/judgeval/instrumentation/llm/llm_google/wrapper.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 
 from judgeval.instrumentation.llm.llm_google.generate_content import (
     wrap_generate_content_sync,
+    wrap_generate_content_stream_sync,
 )
 
 if TYPE_CHECKING:
@@ -24,6 +25,7 @@ def wrap_google_client(client: Client) -> Client:
 
     if isinstance(client, Client):
         wrap_generate_content_sync(client)
+        wrap_generate_content_stream_sync(client)
         return client
     else:
         raise TypeError(f"Invalid client type: {type(client)}")

--- a/src/tests/instrumentation/llm/google/test_generate_content_stream.py
+++ b/src/tests/instrumentation/llm/google/test_generate_content_stream.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+import pytest
+
+from judgeval.judgment_attribute_keys import AttributeKeys
+from judgeval.instrumentation.llm.llm_google.generate_content import (
+    wrap_generate_content_stream_sync,
+)
+
+
+def make_google_stream_chunk(text=None, prompt_tokens=None, completion_tokens=None):
+    chunk = MagicMock()
+    chunk.text = text
+    chunk.model_version = None
+    if prompt_tokens is not None or completion_tokens is not None:
+        chunk.usage_metadata = MagicMock(
+            prompt_token_count=prompt_tokens or 0,
+            candidates_token_count=completion_tokens or 0,
+            cached_content_token_count=None,
+        )
+    else:
+        chunk.usage_metadata = None
+    return chunk
+
+
+class TestGoogleGenerateContentStream:
+    def test_creates_span(self, tracer, collecting_exporter, google_client):
+        chunks = [make_google_stream_chunk(text="Hi")]
+        google_client.models.generate_content_stream = MagicMock(
+            return_value=iter(chunks)
+        )
+        wrap_generate_content_stream_sync(google_client)
+        list(google_client.models.generate_content_stream(model="gemini-2.0-flash", contents="hello"))
+        assert any(s.name == "GOOGLE_API_CALL" for s in collecting_exporter.spans)
+
+    def test_span_has_llm_kind(self, tracer, collecting_exporter, google_client):
+        chunks = [make_google_stream_chunk(text="Hi")]
+        google_client.models.generate_content_stream = MagicMock(
+            return_value=iter(chunks)
+        )
+        wrap_generate_content_stream_sync(google_client)
+        list(google_client.models.generate_content_stream(model="gemini-2.0-flash", contents="hello"))
+        span = next(s for s in collecting_exporter.spans if s.name == "GOOGLE_API_CALL")
+        assert span.attributes.get(AttributeKeys.JUDGMENT_SPAN_KIND) == "llm"
+
+    def test_accumulates_text_across_chunks(
+        self, tracer, collecting_exporter, google_client
+    ):
+        chunks = [
+            make_google_stream_chunk(text="Hello "),
+            make_google_stream_chunk(text="world"),
+            make_google_stream_chunk(text=None, prompt_tokens=8, completion_tokens=2),
+        ]
+        google_client.models.generate_content_stream = MagicMock(
+            return_value=iter(chunks)
+        )
+        wrap_generate_content_stream_sync(google_client)
+        list(google_client.models.generate_content_stream(model="gemini-2.0-flash", contents="hello"))
+        span = next(s for s in collecting_exporter.spans if s.name == "GOOGLE_API_CALL")
+        assert span.attributes.get(AttributeKeys.GEN_AI_COMPLETION) == "Hello world"
+
+    def test_records_token_usage_from_final_chunk(
+        self, tracer, collecting_exporter, google_client
+    ):
+        chunks = [
+            make_google_stream_chunk(text="A"),
+            make_google_stream_chunk(text="B", prompt_tokens=15, completion_tokens=7),
+        ]
+        google_client.models.generate_content_stream = MagicMock(
+            return_value=iter(chunks)
+        )
+        wrap_generate_content_stream_sync(google_client)
+        list(google_client.models.generate_content_stream(model="gemini-2.0-flash", contents="hello"))
+        span = next(s for s in collecting_exporter.spans if s.name == "GOOGLE_API_CALL")
+        assert (
+            span.attributes.get(AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS)
+            == 15
+        )
+        assert span.attributes.get(AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS) == 7
+
+    def test_chunks_without_text_do_not_add_to_completion(
+        self, tracer, collecting_exporter, google_client
+    ):
+        chunks = [
+            make_google_stream_chunk(text=None),
+            make_google_stream_chunk(text="Only this"),
+        ]
+        google_client.models.generate_content_stream = MagicMock(
+            return_value=iter(chunks)
+        )
+        wrap_generate_content_stream_sync(google_client)
+        list(google_client.models.generate_content_stream(model="gemini-2.0-flash", contents="hello"))
+        span = next(s for s in collecting_exporter.spans if s.name == "GOOGLE_API_CALL")
+        assert span.attributes.get(AttributeKeys.GEN_AI_COMPLETION) == "Only this"
+
+    def test_error_sets_error_status(
+        self, tracer, collecting_exporter, google_client
+    ):
+        def failing_stream(*args, **kwargs):
+            yield make_google_stream_chunk(text="A")
+            raise RuntimeError("stream failed")
+
+        google_client.models.generate_content_stream = failing_stream
+        wrap_generate_content_stream_sync(google_client)
+        with pytest.raises(RuntimeError):
+            list(google_client.models.generate_content_stream(model="gemini-2.0-flash", contents="hello"))
+        span = next(s for s in collecting_exporter.spans if s.name == "GOOGLE_API_CALL")
+        assert span.status.status_code.name == "ERROR"
+
+    def test_wrap_replaces_method(self, tracer, google_client):
+        original = google_client.models.generate_content_stream
+        wrap_generate_content_stream_sync(google_client)
+        assert google_client.models.generate_content_stream is not original
+
+    def test_yields_all_chunks_unchanged(self, tracer, google_client):
+        chunk1 = make_google_stream_chunk(text="A")
+        chunk2 = make_google_stream_chunk(text="B")
+        google_client.models.generate_content_stream = MagicMock(
+            return_value=iter([chunk1, chunk2])
+        )
+        wrap_generate_content_stream_sync(google_client)
+        result = list(
+            google_client.models.generate_content_stream(
+                model="gemini-2.0-flash", contents="hello"
+            )
+        )
+        assert result == [chunk1, chunk2]


### PR DESCRIPTION
## Summary

`wrap_google_client` only patched `client.models.generate_content` (non-streaming). Any call to `client.models.generate_content_stream(...)` produced **no OTel span**, no token tracking, and no content capture.

- Add `wrap_generate_content_stream_sync` in `generate_content.py` using `immutable_wrap_sync_iterator`
- Update `wrap_google_client` in `wrapper.py` to apply both wrappers
- Add 8 tests in `test_generate_content_stream.py`

### Behaviour

| Hook | What it does |
|------|-------------|
| `pre_hook` | Starts `GOOGLE_API_CALL` span, logs prompt and model name |
| `yield_hook` | Accumulates text across chunks; captures `usage_metadata` from any chunk that provides it (typically the final one) |
| `finally_hook` | Writes `gen_ai.completion`, token counts, and resolved model name to span; closes span |
| `error_hook` | Sets `ERROR` status on span if iteration raises |

### Tests (8)

1. `test_creates_span` — streaming call creates a `GOOGLE_API_CALL` span
2. `test_span_has_llm_kind` — span carries `JUDGMENT_SPAN_KIND = "llm"`
3. `test_accumulates_text_across_chunks` — text from multiple chunks is joined
4. `test_records_token_usage_from_final_chunk` — prompt/completion counts from `usage_metadata`
5. `test_chunks_without_text_do_not_add_to_completion` — `chunk.text = None` is skipped
6. `test_error_sets_error_status` — mid-stream exception sets `ERROR` on span
7. `test_wrap_replaces_method` — `generate_content_stream` is replaced after wrapping
8. `test_yields_all_chunks_unchanged` — caller receives all original chunks

Closes #759

## Checklist
- [x] Tests added
- [x] Follows existing `immutable_wrap_sync_iterator` pattern (see `llm_together/chat_completions.py`)
- [x] No new external dependencies
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval/pull/760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->