### PR TITLE
Harden Python package manifest validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,8 +36,7 @@ jobs:
 
       - name: Build distributions
         run: |
-          mkdir -p .jql-source/judgment-mono
-          echo "PRIVATE MONOREPO CONTENT" > .jql-source/judgment-mono/PRIVATE_SOURCE_MARKER
+          python scripts/check_distribution_contents.py --plant
           pip install uv
           uv build
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Build distributions
         run: |
           mkdir -p .jql-source/judgment-mono
-          touch .jql-source/judgment-mono/PRIVATE_SOURCE_MARKER
+          echo "PRIVATE MONOREPO CONTENT" > .jql-source/judgment-mono/PRIVATE_SOURCE_MARKER
           pip install uv
           uv build
 

--- a/scripts/check_distribution_contents.py
+++ b/scripts/check_distribution_contents.py
@@ -86,9 +86,8 @@ def archive_files(path: Path) -> dict[str, bytes]:
 
 def expected_names(path: Path, names: set[str], tracked: set[str]) -> set[str]:
     if path.suffix == ".whl":
-        dist_info_roots = {
-            name.split("/", 1)[0] for name in names if ".dist-info/" in name
-        }
+        roots = {name.split("/", 1)[0] for name in names}
+        dist_info_roots = {root for root in roots if root.endswith(".dist-info")}
         if len(dist_info_roots) != 1:
             raise RuntimeError(
                 f"wheel must have one dist-info root, found {dist_info_roots}"

--- a/scripts/check_distribution_contents.py
+++ b/scripts/check_distribution_contents.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 import tarfile
 import zipfile
 from pathlib import Path
@@ -35,18 +36,19 @@ def tracked_package_files() -> set[str]:
         ["git", "ls-files", "-z", "--", "src/judgeval"],
         check=True,
         capture_output=True,
+        text=True,
     )
-    return {value.decode("utf-8") for value in result.stdout.split(b"\0") if value}
+    return {name for name in result.stdout.split("\0") if name}
 
 
-def archive_files(path: Path) -> dict[str, bytes]:
+def archive_entries(path: Path) -> list[tuple[str, bytes]]:
     if path.suffix == ".whl":
         with zipfile.ZipFile(path) as archive:
-            return {
-                info.filename: archive.read(info)
+            return [
+                (info.filename, archive.read(info))
                 for info in archive.infolist()
                 if not info.is_dir()
-            }
+            ]
     if path.name.endswith(".tar.gz"):
         with tarfile.open(path, "r:gz") as archive:
             members = archive.getmembers()
@@ -63,16 +65,23 @@ def archive_files(path: Path) -> dict[str, bytes]:
                 raise RuntimeError(
                     f"sdist contains links or special entries: {', '.join(special)}"
                 )
-            files = {}
-            for member in members:
-                if not member.isfile():
-                    continue
-                extracted = archive.extractfile(member)
-                if extracted is None:
-                    raise RuntimeError(f"could not read sdist member: {member.name}")
-                files[member.name.removeprefix(f"{root}/")] = extracted.read()
-            return files
+            return [
+                (
+                    member.name.removeprefix(f"{root}/"),
+                    archive.extractfile(member).read(),
+                )
+                for member in members
+                if member.isfile()
+            ]
     raise ValueError(f"Unsupported distribution archive: {path}")
+
+
+def archive_files(path: Path) -> dict[str, bytes]:
+    entries = archive_entries(path)
+    files = dict(entries)
+    if len(files) != len(entries):
+        raise RuntimeError("archive contains duplicate entries")
+    return files
 
 
 def expected_names(path: Path, names: set[str], tracked: set[str]) -> set[str]:
@@ -105,10 +114,9 @@ def distribution_errors(path: Path, tracked: set[str]) -> list[str]:
         errors.append(f"missing files: {', '.join(missing)}")
     if len(files) > MAX_ARCHIVE_FILES:
         errors.append(f"contains {len(files)} files; limit is {MAX_ARCHIVE_FILES}")
-    if path.stat().st_size > MAX_ARCHIVE_BYTES:
-        errors.append(
-            f"archive is {path.stat().st_size} bytes; limit is {MAX_ARCHIVE_BYTES}"
-        )
+    archive_bytes = path.stat().st_size
+    if archive_bytes > MAX_ARCHIVE_BYTES:
+        errors.append(f"archive is {archive_bytes} bytes; limit is {MAX_ARCHIVE_BYTES}")
     unpacked_bytes = sum(len(content) for content in files.values())
     if unpacked_bytes > MAX_UNPACKED_BYTES:
         errors.append(
@@ -121,6 +129,12 @@ def distribution_errors(path: Path, tracked: set[str]) -> list[str]:
     if marked:
         errors.append(f"private-source marker found in: {', '.join(marked)}")
     return errors
+
+
+def plant_marker() -> None:
+    marker = Path(".jql-source/judgment-mono/PRIVATE_SOURCE_MARKER")
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_bytes(PRIVATE_SOURCE_MARKER)
 
 
 def main() -> None:
@@ -141,4 +155,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    if "--plant" in sys.argv:
+        plant_marker()
+    else:
+        main()

--- a/scripts/check_distribution_contents.py
+++ b/scripts/check_distribution_contents.py
@@ -1,57 +1,126 @@
 #!/usr/bin/env python3
-"""Validate that built distributions contain only public package files."""
+"""Validate built distributions against the tracked public package manifest."""
 
 from __future__ import annotations
 
+import subprocess
 import tarfile
 import zipfile
 from pathlib import Path
 
 
-GENERATED_MODULES = {
-    "judgeval/jql/_generated_contract.py",
-    "judgeval/jql/_generated_transport.py",
+PRIVATE_SOURCE_MARKER = b"PRIVATE MONOREPO CONTENT"
+MAX_ARCHIVE_FILES = 1_000
+MAX_ARCHIVE_BYTES = 5 * 1024 * 1024
+MAX_UNPACKED_BYTES = 10 * 1024 * 1024
+SDIST_METADATA = {
+    ".gitignore",
+    "LICENSE.md",
+    "README.md",
+    "hatch_build.py",
+    "pyproject.toml",
+    "PKG-INFO",
+}
+WHEEL_METADATA = {
+    "METADATA",
+    "WHEEL",
+    "entry_points.txt",
+    "licenses/LICENSE.md",
+    "RECORD",
 }
 
 
-def archive_names(path: Path) -> set[str]:
+def tracked_package_files() -> set[str]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--", "src/judgeval"],
+        check=True,
+        capture_output=True,
+    )
+    return {value.decode("utf-8") for value in result.stdout.split(b"\0") if value}
+
+
+def archive_files(path: Path) -> dict[str, bytes]:
     if path.suffix == ".whl":
         with zipfile.ZipFile(path) as archive:
-            return set(archive.namelist())
+            return {
+                info.filename: archive.read(info)
+                for info in archive.infolist()
+                if not info.is_dir()
+            }
     if path.name.endswith(".tar.gz"):
         with tarfile.open(path, "r:gz") as archive:
-            names = archive.getnames()
-        roots = {name.split("/", 1)[0] for name in names}
-        if len(roots) != 1:
-            raise RuntimeError(f"sdist must have one archive root, found {roots}")
-        root = roots.pop()
-        return {name.removeprefix(f"{root}/") for name in names if name != root}
+            members = archive.getmembers()
+            roots = {member.name.split("/", 1)[0] for member in members}
+            if len(roots) != 1:
+                raise RuntimeError(f"sdist must have one archive root, found {roots}")
+            root = roots.pop()
+            special = [
+                member.name
+                for member in members
+                if not member.isfile() and not member.isdir()
+            ]
+            if special:
+                raise RuntimeError(
+                    f"sdist contains links or special entries: {', '.join(special)}"
+                )
+            files = {}
+            for member in members:
+                if not member.isfile():
+                    continue
+                extracted = archive.extractfile(member)
+                if extracted is None:
+                    raise RuntimeError(f"could not read sdist member: {member.name}")
+                files[member.name.removeprefix(f"{root}/")] = extracted.read()
+            return files
     raise ValueError(f"Unsupported distribution archive: {path}")
 
 
-def unexpected_names(path: Path, names: set[str]) -> set[str]:
+def expected_names(path: Path, names: set[str], tracked: set[str]) -> set[str]:
     if path.suffix == ".whl":
-        return {
-            name
-            for name in names
-            if not name.startswith("judgeval/")
-            and not name.split("/", 1)[0].endswith(".dist-info")
+        dist_info_roots = {
+            name.split("/", 1)[0] for name in names if ".dist-info/" in name
         }
-    allowed = {
-        ".gitignore",
-        "LICENSE.md",
-        "README.md",
-        "hatch_build.py",
-        "pyproject.toml",
-        "PKG-INFO",
-        "src",
-        "src/judgeval",
-    }
-    return {
-        name
-        for name in names
-        if name not in allowed and not name.startswith("src/judgeval/")
-    }
+        if len(dist_info_roots) != 1:
+            raise RuntimeError(
+                f"wheel must have one dist-info root, found {dist_info_roots}"
+            )
+        dist_info = dist_info_roots.pop()
+        package_files = {name.removeprefix("src/") for name in tracked}
+        metadata = {f"{dist_info}/{name}" for name in WHEEL_METADATA}
+        return package_files | metadata
+    return tracked | SDIST_METADATA
+
+
+def distribution_errors(path: Path, tracked: set[str]) -> list[str]:
+    files = archive_files(path)
+    names = set(files)
+    expected = expected_names(path, names, tracked)
+    errors = []
+
+    unexpected = sorted(names - expected)
+    if unexpected:
+        errors.append(f"unexpected files: {', '.join(unexpected)}")
+    missing = sorted(expected - names)
+    if missing:
+        errors.append(f"missing files: {', '.join(missing)}")
+    if len(files) > MAX_ARCHIVE_FILES:
+        errors.append(f"contains {len(files)} files; limit is {MAX_ARCHIVE_FILES}")
+    if path.stat().st_size > MAX_ARCHIVE_BYTES:
+        errors.append(
+            f"archive is {path.stat().st_size} bytes; limit is {MAX_ARCHIVE_BYTES}"
+        )
+    unpacked_bytes = sum(len(content) for content in files.values())
+    if unpacked_bytes > MAX_UNPACKED_BYTES:
+        errors.append(
+            f"unpacked size is {unpacked_bytes} bytes; limit is {MAX_UNPACKED_BYTES}"
+        )
+
+    marked = sorted(
+        name for name, content in files.items() if PRIVATE_SOURCE_MARKER in content
+    )
+    if marked:
+        errors.append(f"private-source marker found in: {', '.join(marked)}")
+    return errors
 
 
 def main() -> None:
@@ -61,22 +130,12 @@ def main() -> None:
     if not distributions:
         raise RuntimeError("No distributions found in dist/")
 
-    errors = []
-    for path in distributions:
-        names = archive_names(path)
-        unexpected = sorted(unexpected_names(path, names))
-        if unexpected:
-            errors.append(f"{path}: unexpected files: {', '.join(unexpected)}")
-
-        generated = (
-            GENERATED_MODULES
-            if path.suffix == ".whl"
-            else {f"src/{name}" for name in GENERATED_MODULES}
-        )
-        missing = sorted(generated - names)
-        if missing:
-            errors.append(f"{path}: missing generated files: {', '.join(missing)}")
-
+    tracked = tracked_package_files()
+    errors = [
+        f"{path}: {error}"
+        for path in distributions
+        for error in distribution_errors(path, tracked)
+    ]
     if errors:
         raise RuntimeError("Invalid distribution contents:\n" + "\n".join(errors))
 

--- a/src/tests/test_distribution_contents.py
+++ b/src/tests/test_distribution_contents.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import importlib.util
+import zipfile
+from pathlib import Path
+from types import ModuleType
+
+
+def load_checker() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "check_distribution_contents.py"
+    )
+    spec = importlib.util.spec_from_file_location("check_distribution_contents", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_wheel(path: Path, files: dict[str, bytes]) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+
+
+def valid_wheel_files() -> dict[str, bytes]:
+    dist_info = "judgeval-1.0.0.dist-info"
+    return {
+        "judgeval/__init__.py": b"",
+        f"{dist_info}/METADATA": b"",
+        f"{dist_info}/WHEEL": b"",
+        f"{dist_info}/entry_points.txt": b"",
+        f"{dist_info}/licenses/LICENSE.md": b"",
+        f"{dist_info}/RECORD": b"",
+    }
+
+
+def test_exact_manifest_rejects_untracked_package_files(tmp_path: Path) -> None:
+    checker = load_checker()
+    wheel = tmp_path / "judgeval-1.0.0-py3-none-any.whl"
+    files = valid_wheel_files()
+    files["judgeval/private_source.py"] = b"secret"
+    write_wheel(wheel, files)
+
+    errors = checker.distribution_errors(wheel, {"src/judgeval/__init__.py"})
+
+    assert errors == ["unexpected files: judgeval/private_source.py"]
+
+
+def test_archive_content_scan_rejects_private_marker(tmp_path: Path) -> None:
+    checker = load_checker()
+    wheel = tmp_path / "judgeval-1.0.0-py3-none-any.whl"
+    files = valid_wheel_files()
+    files["judgeval/__init__.py"] = checker.PRIVATE_SOURCE_MARKER
+    write_wheel(wheel, files)
+
+    errors = checker.distribution_errors(wheel, {"src/judgeval/__init__.py"})
+
+    assert errors == ["private-source marker found in: judgeval/__init__.py"]

--- a/src/tests/test_distribution_contents.py
+++ b/src/tests/test_distribution_contents.py
@@ -5,6 +5,8 @@ import zipfile
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 
 def load_checker() -> ModuleType:
     path = (
@@ -59,3 +61,17 @@ def test_archive_content_scan_rejects_private_marker(tmp_path: Path) -> None:
     errors = checker.distribution_errors(wheel, {"src/judgeval/__init__.py"})
 
     assert errors == ["private-source marker found in: judgeval/__init__.py"]
+
+
+def test_rejects_duplicate_archive_entries(tmp_path: Path) -> None:
+    checker = load_checker()
+    wheel = tmp_path / "judgeval-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        for name, content in valid_wheel_files().items():
+            archive.writestr(name, content)
+        archive.writestr("judgeval/__init__.py", b"duplicate copy")
+
+    with pytest.raises(RuntimeError) as error:
+        checker.distribution_errors(wheel, {"src/judgeval/__init__.py"})
+
+    assert str(error.value) == "archive contains duplicate entries"


### PR DESCRIPTION
## Summary

- compare wheel and sdist contents against an exact manifest derived from tracked public package files
- reject unexpected or missing files, archive links/special entries, oversized artifacts, and a private-source content marker
- add adversarial tests proving that an extra file under `judgeval/` and marker content are rejected
- exercise the content marker in CI before building distributions

## Why

The initial checker in #756 allowed any path under `judgeval/` or `src/judgeval/`. That protected the repository root, but it was still a directory-prefix allow-list: an accidental copy into the public package namespace would pass. The marker was also an empty filename-only sentinel, so it did not test archive content.

This change makes the package manifest exact and content-aware.

## Stack

1. #756 — public JQL packaging and the initial distribution checker
2. **This PR** — package-manifest hardening

Base branch: `codex/jud-8016-public-jql`. Merge after #756.

## Validation

- `uv run ruff check .`
- `uv run mypy src/judgeval`
- `uv run pytest src/tests -q` — 634 passed
- `uv build`
- `uv run python scripts/check_distribution_contents.py`
