### PR TITLE
fix: validate dataset save_as file_type and fix save/load round-trip

### DIFF
--- a/src/judgeval/datasets/dataset.py
+++ b/src/judgeval/datasets/dataset.py
@@ -82,6 +82,32 @@ def example_from_dataset_entry(entry: Dict[str, Any]) -> Example:
     return example
 
 
+def _parse_examples_file_data(data: Any) -> List[Any]:
+    """Normalize JSON/YAML file contents into a list of example entries."""
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict) and "examples" in data:
+        examples = data["examples"]
+        if not isinstance(examples, list):
+            raise ValueError("'examples' must be a list.")
+        return examples
+    raise ValueError("Expected a list of examples or an object with an 'examples' key.")
+
+
+def _examples_from_file_entries(entries: Iterable[Any]) -> List[Example]:
+    examples: List[Example] = []
+    for entry in entries:
+        if isinstance(entry, Example):
+            examples.append(entry)
+        elif isinstance(entry, dict):
+            examples.append(example_from_dataset_entry(entry))
+        else:
+            raise TypeError(
+                f"Each example must be a dict or Example, got {type(entry).__name__}."
+            )
+    return examples
+
+
 @dataclass
 class DatasetInfo:
     """Summary metadata returned when listing datasets.
@@ -240,17 +266,7 @@ class Dataset:
         """
         with open(file_path, "rb") as file:
             data = orjson.loads(file.read())
-        examples = []
-        for e in data:
-            if isinstance(e, dict):
-                name = e.get("name")
-                example = Example(name=name)
-                for key, value in e.items():
-                    if key != "name":
-                        example._properties[key] = value
-                examples.append(example)
-            else:
-                examples.append(e)
+        examples = _examples_from_file_entries(_parse_examples_file_data(data))
         self.add_examples(examples, batch_size=batch_size)
 
     def add_from_yaml(self, file_path: str, batch_size: int = 100) -> None:
@@ -264,17 +280,7 @@ class Dataset:
         """
         with open(file_path, "r") as file:
             data = yaml.safe_load(file)
-        examples = []
-        for e in data:
-            if isinstance(e, dict):
-                name = e.get("name")
-                example = Example(name=name)
-                for key, value in e.items():
-                    if key != "name":
-                        example._properties[key] = value
-                examples.append(example)
-            else:
-                examples.append(e)
+        examples = _examples_from_file_entries(_parse_examples_file_data(data))
         self.add_examples(examples, batch_size=batch_size)
 
     def add_examples(self, examples: Iterable[Example], batch_size: int = 100) -> None:
@@ -421,6 +427,8 @@ class Dataset:
         elif file_type == "yaml":
             with open(complete_path, "w") as file:
                 yaml.dump({"examples": examples_data}, file, default_flow_style=False)
+        else:
+            raise ValueError(f"file_type must be 'json' or 'yaml', got {file_type!r}.")
 
     def __iter__(self):
         return iter(self.examples or [])

--- a/src/judgeval/datasets/dataset.py
+++ b/src/judgeval/datasets/dataset.py
@@ -68,11 +68,17 @@ def example_from_dataset_entry(entry: Dict[str, Any]) -> Example:
             if k not in ("example_id", "created_at", "name")
         }
 
-    example = Example(
-        example_id=entry.get("example_id", "") or "",
-        created_at=entry.get("created_at", "") or "",
-        name=entry.get("name"),
-    )
+    example_kwargs: Dict[str, Any] = {}
+    example_id = entry.get("example_id")
+    if example_id:
+        example_kwargs["example_id"] = example_id
+    created_at = entry.get("created_at")
+    if created_at:
+        example_kwargs["created_at"] = created_at
+    if "name" in entry:
+        example_kwargs["name"] = entry.get("name")
+
+    example = Example(**example_kwargs)
     for key, value in data.items():
         example._properties[key] = value
 

--- a/src/tests/datasets/test_dataset.py
+++ b/src/tests/datasets/test_dataset.py
@@ -122,6 +122,15 @@ class TestDatasetLoadFromFile:
         assert examples[0].example_id == "e1"
         assert examples[0]["input"] == "q"
 
+    def test_examples_from_file_entries_generates_ids_for_plain_entries(self):
+        examples = _examples_from_file_entries([{"input": "a"}, {"input": "b"}])
+        assert len(examples) == 2
+        assert examples[0].example_id
+        assert examples[1].example_id
+        assert examples[0].created_at
+        assert examples[1].created_at
+        assert examples[0].example_id != examples[1].example_id
+
     def test_add_from_json_loads_save_as_output(self):
         client = MagicMock()
         client.post_projects_datasets_by_dataset_identifier_examples.return_value = {
@@ -324,6 +333,12 @@ class TestDatasetEntrySerialization:
     def test_example_from_dataset_entry_flat_fallback(self):
         entry = {"example_id": "e1", "created_at": "2026-01-01", "input": "q"}
         example = example_from_dataset_entry(entry)
+        assert example["input"] == "q"
+
+    def test_example_from_dataset_entry_generates_id_when_missing(self):
+        example = example_from_dataset_entry({"input": "q"})
+        assert example.example_id
+        assert example.created_at
         assert example["input"] == "q"
 
 

--- a/src/tests/datasets/test_dataset.py
+++ b/src/tests/datasets/test_dataset.py
@@ -12,6 +12,8 @@ from judgeval.datasets.dataset import (
     Dataset,
     DatasetVersion,
     _batch_examples,
+    _examples_from_file_entries,
+    _parse_examples_file_data,
     example_from_dataset_entry,
     example_to_dataset_entry,
 )
@@ -90,6 +92,95 @@ class TestDatasetSave:
             with open(os.path.join(d, "empty.json")) as f:
                 data = json.load(f)
             assert data["examples"] == []
+
+    def test_save_as_invalid_file_type_raises(self):
+        ds = _make_dataset()
+        with tempfile.TemporaryDirectory() as d:
+            with pytest.raises(ValueError, match="file_type must be 'json' or 'yaml'"):
+                ds.save_as("csv", d, save_name="out")  # type: ignore[arg-type]
+            assert not os.path.exists(os.path.join(d, "out.csv"))
+
+
+class TestDatasetLoadFromFile:
+    def test_parse_examples_file_data_accepts_list(self):
+        data = [{"input": "q"}]
+        assert _parse_examples_file_data(data) == data
+
+    def test_parse_examples_file_data_accepts_save_as_wrapper(self):
+        data = {"examples": [{"input": "q"}]}
+        assert _parse_examples_file_data(data) == [{"input": "q"}]
+
+    def test_parse_examples_file_data_rejects_invalid_wrapper(self):
+        with pytest.raises(ValueError, match="'examples' must be a list"):
+            _parse_examples_file_data({"examples": "not-a-list"})
+
+    def test_examples_from_file_entries_uses_dataset_entry_shape(self):
+        examples = _examples_from_file_entries(
+            [{"example_id": "e1", "created_at": "2026-01-01", "input": "q"}]
+        )
+        assert len(examples) == 1
+        assert examples[0].example_id == "e1"
+        assert examples[0]["input"] == "q"
+
+    def test_add_from_json_loads_save_as_output(self):
+        client = MagicMock()
+        client.post_projects_datasets_by_dataset_identifier_examples.return_value = {
+            "example_ids": [],
+            "version_added": 2,
+        }
+        source = Dataset(
+            name="source-ds",
+            project_id="proj-1",
+            project_name="proj",
+            examples=[Example.create(input="q", output="a")],
+            client=client,
+        )
+        target = Dataset(
+            name="target-ds",
+            project_id="proj-1",
+            project_name="proj",
+            examples=[],
+            client=client,
+        )
+        with tempfile.TemporaryDirectory() as d:
+            source.save_as("json", d, save_name="out")
+            target.add_from_json(os.path.join(d, "out.json"))
+
+        payload = client.post_projects_datasets_by_dataset_identifier_examples.call_args.kwargs[
+            "payload"
+        ]
+        assert payload["examples"][0]["input"] == "q"
+        assert payload["examples"][0]["output"] == "a"
+
+    def test_add_from_yaml_loads_save_as_output(self):
+        client = MagicMock()
+        client.post_projects_datasets_by_dataset_identifier_examples.return_value = {
+            "example_ids": [],
+            "version_added": 2,
+        }
+        source = Dataset(
+            name="source-ds",
+            project_id="proj-1",
+            project_name="proj",
+            examples=[Example.create(input="q", output="a")],
+            client=client,
+        )
+        target = Dataset(
+            name="target-ds",
+            project_id="proj-1",
+            project_name="proj",
+            examples=[],
+            client=client,
+        )
+        with tempfile.TemporaryDirectory() as d:
+            source.save_as("yaml", d, save_name="out")
+            target.add_from_yaml(os.path.join(d, "out.yaml"))
+
+        payload = client.post_projects_datasets_by_dataset_identifier_examples.call_args.kwargs[
+            "payload"
+        ]
+        assert payload["examples"][0]["input"] == "q"
+        assert payload["examples"][0]["output"] == "a"
 
 
 class TestAddExamples:


### PR DESCRIPTION
## Summary
Fixes two related dataset file export/import bugs.

## Bug 1
`Dataset.save_as("csv", ...)` silently wrote no file. Now raises a ValueError.

## Bug 2
Files exported via `save_as()` could not be re-imported with `add_from_json()`.
save_as writes `{"examples": [...]}` but add_from_json expected a bare list.

## Testing
pytest src/tests/datasets/test_dataset.py — 30 passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval/pull/763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->