### PR TITLE
chore(ci): report AWS caller account (temporary)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,6 +156,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
+      - name: Report AWS account ID
+        run: aws sts get-caller-identity --query Account --output text
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Temporary diagnostic to report the AWS account ID used by the Judgeval E2E workflow.

This prints only `sts:GetCallerIdentity.Account`; it does not print credentials or secret values. The PR and branch will be removed after the account ID is captured.