### PR TITLE
ci: pin E2E secrets to primary AWS account

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,6 +147,7 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     env:
+      EXPECTED_AWS_ACCOUNT_ID: "762168327048"
       TEST_TIMEOUT_SECONDS: ${{ secrets.TEST_TIMEOUT_SECONDS }}
     steps:
       - name: Configure AWS Credentials
@@ -155,6 +156,14 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
+
+      - name: Verify AWS account
+        run: |
+          actual_account_id=$(aws sts get-caller-identity --query Account --output text)
+          if [ "$actual_account_id" != "$EXPECTED_AWS_ACCOUNT_ID" ]; then
+            echo "::error::Expected AWS account $EXPECTED_AWS_ACCOUNT_ID, got $actual_account_id"
+            exit 1
+          fi
 
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Pin Judgeval SDK E2E secret reads to the primary Judgment AWS account (`762168327048`).

The workflow already selects the intended environment-specific secret paths:

- `stg/api-keys/e2e-tests` for PRs targeting `staging`
- `prod/api-keys/e2e-tests` for PRs targeting `main`

However, the repository's current static AWS credentials authenticate to legacy account `585008087243`, so those same names resolve there. This change verifies the caller account immediately after AWS authentication and fails before reading any secret if the credentials point elsewhere.

## Changes

- Declare `762168327048` as the expected AWS account for E2E jobs.
- Call `sts:GetCallerIdentity` after credential configuration.
- Fail with an actionable error when the repository credentials target another account.
- Keep the existing staging/production secret selection unchanged.

## Validation

- `git diff --check`
- Parsed `.github/workflows/ci.yaml` successfully with Ruby YAML

## Rollout dependency

This PR depends on [JudgmentLabs/judgment-mono#3287](https://github.com/JudgmentLabs/judgment-mono/pull/3287):

1. Merge and apply the Terraform common-root changes in account `762168327048`.
2. Populate both E2E secret values out-of-band, including a valid replacement `OPENAI_API_KEY`.
3. Rotate this repository's `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` Actions secrets to the primary account's workflow identity.
4. Rerun this PR's E2E jobs.

The E2E jobs are expected to fail at the account guard until step 3 is complete.
