### PR TITLE
test: remove live Together E2E dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,6 @@ jobs:
     env:
       PYTHONPATH: "."
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
@@ -148,6 +147,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_TIMEOUT_SECONDS: ${{ secrets.TEST_TIMEOUT_SECONDS }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/src/e2etests/test_tracer.py
+++ b/src/e2etests/test_tracer.py
@@ -7,7 +7,6 @@ import pytest
 import orjson
 from openai import OpenAI, AsyncOpenAI
 from anthropic import Anthropic, AsyncAnthropic
-from together import Together, AsyncTogether  # type: ignore[import-untyped]
 from google import genai
 
 from judgeval import Tracer
@@ -35,12 +34,10 @@ tracer = Tracer.init(project_name=project_name)
 
 openai_client = wrap(OpenAI())
 anthropic_client = wrap(Anthropic())
-together_client = wrap(Together(api_key=os.getenv("TOGETHER_API_KEY")))
 google_client = wrap(genai.Client(api_key=os.getenv("GOOGLE_API_KEY")))
 
 openai_client_async = wrap(AsyncOpenAI())
 anthropic_client_async = wrap(AsyncAnthropic())
-together_client_async = wrap(AsyncTogether(api_key=os.getenv("TOGETHER_API_KEY")))
 
 QUERY_RETRY = 60
 PROMPT = "I need you to solve this math problem: 1 + 1 = ?"
@@ -75,18 +72,6 @@ def anthropic_llm_call():
         model="claude-haiku-4-5",
         messages=[{"role": "user", "content": PROMPT}],
         max_tokens=30,
-    )
-    return format(BaseTracer.get_current_span().get_span_context().trace_id, "032x")
-
-
-@BaseTracer.observe()
-def together_llm_call():
-    together_client.chat.completions.create(
-        model="meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-        messages=[
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": PROMPT},
-        ],
     )
     return format(BaseTracer.get_current_span().get_span_context().trace_id, "032x")
 
@@ -135,26 +120,6 @@ def anthropic_streaming_llm_call():
 
 
 @BaseTracer.observe()
-def together_streaming_llm_call():
-    stream = together_client.chat.completions.create(
-        model="meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-        messages=[
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": PROMPT},
-        ],
-        stream=True,
-        stream_options={"include_usage": True},
-    )
-
-    accumulated_content = ""
-    for chunk in stream:
-        if chunk.choices and chunk.choices[0].delta.content:
-            accumulated_content += chunk.choices[0].delta.content
-
-    return format(BaseTracer.get_current_span().get_span_context().trace_id, "032x")
-
-
-@BaseTracer.observe()
 async def openai_async_llm_call():
     await openai_client_async.chat.completions.create(
         model="gpt-4o-mini", messages=[{"role": "user", "content": PROMPT}]
@@ -168,15 +133,6 @@ async def anthropic_async_llm_call():
         model="claude-haiku-4-5",
         messages=[{"role": "user", "content": PROMPT}],
         max_tokens=30,
-    )
-    return format(BaseTracer.get_current_span().get_span_context().trace_id, "032x")
-
-
-@BaseTracer.observe()
-async def together_async_llm_call():
-    await together_client_async.chat.completions.create(
-        model="meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-        messages=[{"role": "user", "content": PROMPT}],
     )
     return format(BaseTracer.get_current_span().get_span_context().trace_id, "032x")
 
@@ -214,26 +170,6 @@ async def anthropic_async_streaming_llm_call():
     async for chunk in stream:
         if hasattr(chunk, "delta") and hasattr(chunk.delta, "text"):
             accumulated_content += chunk.delta.text or ""
-
-    return format(BaseTracer.get_current_span().get_span_context().trace_id, "032x")
-
-
-@BaseTracer.observe()
-async def together_async_streaming_llm_call():
-    stream = await together_client_async.chat.completions.create(
-        model="meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-        messages=[
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": PROMPT},
-        ],
-        stream=True,
-        stream_options={"include_usage": True},
-    )
-
-    accumulated_content = ""
-    async for chunk in stream:
-        if chunk.choices and chunk.choices[0].delta.content:
-            accumulated_content += chunk.choices[0].delta.content
 
     return format(BaseTracer.get_current_span().get_span_context().trace_id, "032x")
 
@@ -319,12 +255,6 @@ def test_anthropic_llm_cost():
     retrieve_llm_cost_helper(trace_id)
 
 
-@pytest.mark.skip(reason="Skipping together client because unreliable")
-def test_together_llm_cost():
-    trace_id = together_llm_call()
-    retrieve_llm_cost_helper(trace_id)
-
-
 @pytest.mark.skip(reason="Skipping google client quotes")
 def test_google_llm_cost():
     trace_id = google_llm_call()
@@ -343,13 +273,6 @@ async def test_anthropic_async_llm_cost():
     retrieve_llm_cost_helper(trace_id)
 
 
-@pytest.mark.skip(reason="Skipping together client because unreliable")
-@pytest.mark.asyncio
-async def test_together_async_llm_cost():
-    trace_id = await together_async_llm_call()
-    retrieve_llm_cost_helper(trace_id)
-
-
 def test_openai_streaming_llm_cost():
     trace_id = openai_streaming_llm_call()
     retrieve_streaming_trace_helper(trace_id)
@@ -357,12 +280,6 @@ def test_openai_streaming_llm_cost():
 
 def test_anthropic_streaming_llm_cost():
     trace_id = anthropic_streaming_llm_call()
-    retrieve_streaming_trace_helper(trace_id)
-
-
-@pytest.mark.skip(reason="Together account blocked")
-def test_together_streaming_llm_cost():
-    trace_id = together_streaming_llm_call()
     retrieve_streaming_trace_helper(trace_id)
 
 
@@ -375,11 +292,4 @@ async def test_openai_async_streaming_llm_cost():
 @pytest.mark.asyncio
 async def test_anthropic_async_streaming_llm_cost():
     trace_id = await anthropic_async_streaming_llm_call()
-    retrieve_streaming_trace_helper(trace_id)
-
-
-@pytest.mark.skip(reason="Together account blocked")
-@pytest.mark.asyncio
-async def test_together_async_streaming_llm_cost():
-    trace_id = await together_async_streaming_llm_call()
     retrieve_streaming_trace_helper(trace_id)


### PR DESCRIPTION
## Summary

Remove the unused live Together dependency from the Judgeval E2E tracer suite.

## Root cause

The Together E2E tests were permanently skipped, but `test_tracer.py` still
instantiated synchronous and asynchronous Together clients at module import
time. Test collection therefore required `TOGETHER_API_KEY` and failed before
reaching the skipped tests.

## Changes

- Remove the skipped Together E2E helpers, clients, and tests.
- Stop injecting `TOGETHER_API_KEY` into the unit-test matrix.
- Supply the remaining live OpenAI, Anthropic, and Google E2E credentials from
  existing GitHub repository secrets.
- Preserve Together instrumentation and its mocked unit coverage.

## Testing

- `uv run pre-commit run --files .github/workflows/ci.yaml src/e2etests/test_tracer.py`
- `uv run pytest -q src/tests/instrumentation/llm/together src/tests/instrumentation/test_wrap_provider.py`
  (`14 passed`)
- `git diff --check`

## Rollout

Merge this PR into `staging`, then rerun the release PR CI against `main`. AWS
Secrets Manager no longer needs a `TOGETHER_API_KEY` field.
