### PR TITLE
feat(jql): explain the opaque 404 from the public JQL API

### DIFF
--- a/src/judgeval/exceptions.py
+++ b/src/judgeval/exceptions.py
@@ -52,6 +52,20 @@ class JudgmentValidationError(JudgmentAPIError):
     ...
 
 
+class JudgmentJQLUnavailableError(JudgmentAPIError):
+    """Raised when a JQL request is answered with HTTP 404.
+
+    The public JQL API returns the same opaque 404 whether JQL is not
+    enabled for the organization or the project does not exist, so this
+    error covers both causes and its detail names them.
+
+    This is distinct from a 503, which means JQL is enabled but
+    temporarily unavailable.
+    """
+
+    ...
+
+
 def map_judgment_api_error(
     error: JudgmentAPIError, message: Optional[str] = None
 ) -> JudgmentAPIError:
@@ -107,6 +121,7 @@ class InvalidJudgeModelError(Exception):
 __all__ = (
     "JudgmentAPIError",
     "JudgmentConflictError",
+    "JudgmentJQLUnavailableError",
     "JudgmentProjectNotFoundError",
     "JudgmentValidationError",
     "JudgmentRuntimeError",

--- a/src/judgeval/judgeval.py
+++ b/src/judgeval/judgeval.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence,
 from judgeval.internal.api import JudgmentSyncClient
 from judgeval.exceptions import (
     JudgmentAPIError,
+    JudgmentJQLUnavailableError,
     JudgmentProjectNotFoundError,
     map_judgment_api_error,
 )
@@ -25,6 +26,12 @@ if TYPE_CHECKING:
         JqlQueryResponse,
         QueryInput,
     )
+
+
+#: Detail the API sends when a JQL-enabled organization asks for a project it
+#: cannot see. Used only to sharpen the 404 message; an unrecognized detail
+#: falls back to naming both possible causes.
+_JQL_PROJECT_NOT_FOUND_DETAIL = "Project not found"
 
 
 class Judgeval:
@@ -222,10 +229,42 @@ class Judgeval:
                 payload,
             )
         except JudgmentAPIError as error:
+            if error.status_code == 404:
+                raise self._jql_unavailable_error(error) from error
             mapped = map_judgment_api_error(error)
             if mapped is error:
                 raise
             raise mapped from error
+
+    def _jql_unavailable_error(
+        self, error: JudgmentAPIError
+    ) -> JudgmentJQLUnavailableError:
+        """Explain the opaque 404 the public JQL API returns.
+
+        The organization-level feature gate runs before the project lookup
+        server-side, so a disabled organization never reaches the project
+        check. That makes the two 404 details disjoint: only a JQL-enabled
+        organization can be told the project is missing. When the detail is
+        anything else, either cause is possible and both are named.
+        """
+        if error.detail == _JQL_PROJECT_NOT_FOUND_DETAIL:
+            detail = (
+                f"Project '{self._project_name}' was not found for this organization."
+            )
+        else:
+            detail = (
+                "JQL is not enabled for this organization, or project "
+                f"'{self._project_name}' was not found — the API returns the same "
+                "404 for both. Contact Judgment to enable JQL for your organization."
+            )
+        return JudgmentJQLUnavailableError(
+            error.status_code,
+            detail,
+            error.response,
+            code=error.code,
+            hint=error.hint,
+            retry_after_seconds=error.retry_after_seconds,
+        )
 
     def discover(
         self,

--- a/src/tests/jql/test_jql.py
+++ b/src/tests/jql/test_jql.py
@@ -10,6 +10,7 @@ from judgeval import Judgeval
 from judgeval.exceptions import (
     JudgmentAPIError,
     JudgmentConflictError,
+    JudgmentJQLUnavailableError,
     JudgmentProjectNotFoundError,
     JudgmentValidationError,
 )
@@ -320,6 +321,73 @@ def test_jql_errors_map_to_typed_sdk_exceptions(
     with pytest.raises(JudgmentAPIError) as server_error:
         client.query(traces())
     assert type(server_error.value) is JudgmentAPIError
+
+
+def _jql_client_raising(
+    monkeypatch: pytest.MonkeyPatch, status_code: int, detail: str
+) -> Judgeval:
+    monkeypatch.setattr("judgeval.judgeval.resolve_project_id", lambda *_: "project-1")
+
+    def fake_request(self, method, url, payload, params=None):  # type: ignore[no-untyped-def]
+        raise JudgmentAPIError(status_code, detail, None, code="Resource not found")
+
+    monkeypatch.setattr(JudgmentSyncClient, "_request", fake_request)
+    return Judgeval(
+        project_name="demo",
+        api_key="api-key",
+        organization_id="org-1",
+        api_url="https://api.example.com/",
+    )
+
+
+def test_jql_404_explains_the_feature_gate_and_the_missing_project(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _jql_client_raising(monkeypatch, 404, "Resource not found")
+
+    with pytest.raises(JudgmentJQLUnavailableError) as raised:
+        client.query(traces())
+
+    message = str(raised.value)
+    assert "JQL is not enabled for this organization" in message
+    assert "project 'demo' was not found" in message
+    assert "Contact Judgment" in message
+    assert raised.value.status_code == 404
+    # The opaque server detail must not survive as the user-facing message.
+    assert "Resource not found" not in message
+
+
+def test_jql_404_for_a_missing_project_does_not_blame_the_feature_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _jql_client_raising(monkeypatch, 404, "Project not found")
+
+    with pytest.raises(JudgmentJQLUnavailableError) as raised:
+        client.query(traces())
+
+    message = str(raised.value)
+    assert message == "404: Project 'demo' was not found for this organization."
+    assert "not enabled" not in message
+
+
+def test_jql_404_error_is_catchable_as_a_plain_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _jql_client_raising(monkeypatch, 404, "Resource not found")
+
+    # Existing callers that catch JudgmentAPIError keep working.
+    with pytest.raises(JudgmentAPIError):
+        client.discover("judges")
+
+
+def test_non_jql_404_is_left_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    from judgeval.exceptions import map_judgment_api_error
+
+    error = JudgmentAPIError(404, "Resource not found", None)
+
+    # The shared mapper is used by datasets and offline tests too, so it must
+    # not turn every 404 in the SDK into a JQL error.
+    assert map_judgment_api_error(error) is error
 
 
 def test_api_error_preserves_code_hint_and_retry_after() -> None:


### PR DESCRIPTION
## 📝 Summary

A valid JQL query from an organization without the `public_jql` feature flag raised a bare `JudgmentAPIError: 404: Resource not found`, giving callers nothing to act on.

- [x] 1. Added `JudgmentJQLUnavailableError` (subclass of `JudgmentAPIError`) for 404s on JQL routes, exported from `judgeval.exceptions`
- [x] 2. Mapped the 404 in `_run_jql` — the single choke point covering `query`, `present`, and `discover`
- [x] 3. Sharpened the message to `Project '<name>' was not found for this organization.` when the server detail is `Project not found`
- [x] 4. Added regression coverage, including a test pinning that non-JQL 404s are left alone

**Before**
```
JudgmentAPIError: 404: Resource not found
```

**After**
```
JudgmentJQLUnavailableError: 404: JQL is not enabled for this organization, or
project 'my-project' was not found — the API returns the same 404 for both.
Contact Judgment to enable JQL for your organization.
```

### Why the message names two causes

`judgeval-server` throws `NotFoundError('Resource not found')` when the `public_jql` flag is off, which is byte-identical to the 404 for a missing project, and the published OpenAPI documents 404 as "Project or public JQL endpoint not found". The SDK therefore **cannot** positively identify the disabled flag, and claiming it could would mislead the much more common case of a typo'd project name. Naming both causes plus the next step is the honest maximum available client-side.

One string does discriminate: the org-level gate runs *before* the project lookup server-side, so a `Project not found` detail can only come from an already-enabled org. That is used to sharpen the message, with a comment marking the coupling and a safe fallback if the server text ever changes.

### Design notes

- The mapping is in `_run_jql`, **not** in `map_judgment_api_error`'s status table — that mapper is shared with `datasets/` and `offline_tests/`, where a 404 has nothing to do with JQL.
- The new error subclasses `JudgmentAPIError`, so existing `except JudgmentAPIError` callers are unaffected (asserted in a test).
- No new attributes on `JudgmentAPIError`, so the exact-`vars()` assertions in `test_jql.py` still hold.
- The parity-gated `_generated_contract.py` / `_generated_transport.py` are untouched.

### Follow-up (not in this PR)

Worth deciding separately: have `judgeval-server` send a distinguishable `error` code for the flag-off case, letting both SDKs state the cause outright instead of inferring it. If the current ambiguity is intentional non-disclosure, leave it as is.

## ✅ Checklist

- [ ] Docs updated ([if necessary](https://github.com/JudgmentLabs/docs)) — deliberately SDK-only; no doc change requested
- [ ] Changelogs are updated ([if necessary](https://github.com/JudgmentLabs/docs/tree/main/content/docs/changelog/%28weekly%29))

## Testing

- `uv run pytest src/tests` → **643 passed**
- `uv run mypy ./src/judgeval/` → clean (196 files)
- `uv run ruff check .` / `ruff format --check .` → clean
- New tests: opaque-404 message, sharpened missing-project message, `except JudgmentAPIError` back-compat, and non-JQL 404 left unmapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval/pull/767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->