### PR TITLE
feat(google): instrument aio.models.generate_content_stream for async streaming

### DIFF
--- a/src/judgeval/instrumentation/llm/llm_google/generate_content.py
+++ b/src/judgeval/instrumentation/llm/llm_google/generate_content.py
@@ -10,7 +10,7 @@ from typing import (
 from opentelemetry.trace import Status, StatusCode
 from judgeval.judgment_attribute_keys import AttributeKeys
 from judgeval.utils.serialize import safe_serialize
-from judgeval.utils.wrappers import immutable_wrap_sync
+from judgeval.utils.wrappers import immutable_wrap_sync, immutable_wrap_async_iterator
 from judgeval.trace import BaseTracer
 
 if TYPE_CHECKING:
@@ -48,6 +48,58 @@ def _format_google_output(
     response: GenerateContentResponse,
 ) -> Tuple[Optional[str], Optional[GenerateContentResponseUsageMetadata]]:
     return response.text, response.usage_metadata
+
+
+def _process_google_stream_chunk(
+    context: Dict[str, Any],
+    chunk: GenerateContentResponse,
+) -> None:
+    if chunk.text:
+        context["accumulated_text"] = context.get("accumulated_text", "") + chunk.text
+    if chunk.usage_metadata is not None:
+        context["usage_data"] = chunk.usage_metadata
+    if hasattr(chunk, "model_version") and chunk.model_version:
+        context["model_version"] = chunk.model_version
+
+
+def _flush_stream_span(ctx: Dict[str, Any]) -> None:
+    span = ctx.get("span")
+    if not span:
+        return
+
+    accumulated = ctx.get("accumulated_text", "")
+    if accumulated:
+        span.set_attribute(AttributeKeys.GEN_AI_COMPLETION, accumulated)
+
+    model_version = ctx.get("model_version") or ctx.get("model_name", "")
+    if model_version:
+        span.set_attribute(AttributeKeys.JUDGMENT_LLM_MODEL_NAME, model_version)
+
+    usage_data = ctx.get("usage_data")
+    if usage_data:
+        prompt_tokens, completion_tokens, cache_read, cache_creation = (
+            _extract_google_tokens(usage_data)
+        )
+        span.set_attribute(
+            AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS,
+            prompt_tokens,
+        )
+        span.set_attribute(
+            AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS, completion_tokens
+        )
+        span.set_attribute(
+            AttributeKeys.JUDGMENT_USAGE_CACHE_READ_INPUT_TOKENS, cache_read
+        )
+        span.set_attribute(
+            AttributeKeys.JUDGMENT_USAGE_CACHE_CREATION_INPUT_TOKENS,
+            cache_creation,
+        )
+        span.set_attribute(
+            AttributeKeys.JUDGMENT_USAGE_METADATA,
+            safe_serialize(usage_data),
+        )
+
+    span.end()
 
 
 def wrap_generate_content_sync(client: Client) -> None:
@@ -119,3 +171,39 @@ def wrap_generate_content_sync(client: Client) -> None:
     )
 
     setattr(client.models, "generate_content", wrapped)
+
+
+def wrap_generate_content_stream_async(client: Client) -> None:
+    original_func = client.aio.models.generate_content_stream
+
+    def pre_hook(ctx: Dict[str, Any], *args: Any, **kwargs: Any) -> None:
+        ctx["span"] = BaseTracer.start_span(
+            "GOOGLE_API_CALL", {AttributeKeys.JUDGMENT_SPAN_KIND: "llm"}
+        )
+        ctx["span"].set_attribute(AttributeKeys.GEN_AI_PROMPT, safe_serialize(kwargs))
+        ctx["model_name"] = kwargs.get("model", "")
+        ctx["span"].set_attribute(
+            AttributeKeys.JUDGMENT_LLM_MODEL_NAME, ctx["model_name"]
+        )
+
+    def yield_hook(ctx: Dict[str, Any], chunk: GenerateContentResponse) -> None:
+        _process_google_stream_chunk(ctx, chunk)
+
+    def error_hook(ctx: Dict[str, Any], error: Exception) -> None:
+        span = ctx.get("span")
+        if span:
+            span.record_exception(error)
+            span.set_status(Status(StatusCode.ERROR))
+
+    def finally_hook(ctx: Dict[str, Any]) -> None:
+        _flush_stream_span(ctx)
+
+    wrapped = immutable_wrap_async_iterator(
+        original_func,
+        pre_hook=pre_hook,
+        yield_hook=yield_hook,
+        error_hook=error_hook,
+        finally_hook=finally_hook,
+    )
+
+    setattr(client.aio.models, "generate_content_stream", wrapped)

--- a/src/judgeval/instrumentation/llm/llm_google/wrapper.py
+++ b/src/judgeval/instrumentation/llm/llm_google/wrapper.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 
 from judgeval.instrumentation.llm.llm_google.generate_content import (
     wrap_generate_content_sync,
+    wrap_generate_content_stream_async,
 )
 
 if TYPE_CHECKING:
@@ -24,6 +25,7 @@ def wrap_google_client(client: Client) -> Client:
 
     if isinstance(client, Client):
         wrap_generate_content_sync(client)
+        wrap_generate_content_stream_async(client)
         return client
     else:
         raise TypeError(f"Invalid client type: {type(client)}")

--- a/src/tests/instrumentation/llm/google/test_generate_content_stream_async.py
+++ b/src/tests/instrumentation/llm/google/test_generate_content_stream_async.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+import pytest
+
+from judgeval.judgment_attribute_keys import AttributeKeys
+from judgeval.instrumentation.llm.llm_google.generate_content import (
+    wrap_generate_content_stream_async,
+)
+
+
+def make_google_stream_chunk(text=None, prompt_tokens=None, completion_tokens=None):
+    chunk = MagicMock()
+    chunk.text = text
+    chunk.model_version = None
+    if prompt_tokens is not None or completion_tokens is not None:
+        chunk.usage_metadata = MagicMock(
+            prompt_token_count=prompt_tokens or 0,
+            candidates_token_count=completion_tokens or 0,
+            cached_content_token_count=None,
+        )
+    else:
+        chunk.usage_metadata = None
+    return chunk
+
+
+def make_async_stream(*chunks):
+    async def _gen(**kwargs):
+        for chunk in chunks:
+            yield chunk
+
+    return _gen
+
+
+class TestGoogleGenerateContentStreamAsync:
+    @pytest.mark.asyncio
+    async def test_creates_span(self, tracer, collecting_exporter, google_client):
+        chunk = make_google_stream_chunk(text="Hi")
+        google_client.aio.models.generate_content_stream = make_async_stream(chunk)
+        wrap_generate_content_stream_async(google_client)
+        async for _ in google_client.aio.models.generate_content_stream(
+            model="gemini-2.0-flash", contents="hello"
+        ):
+            pass
+        assert any(s.name == "GOOGLE_API_CALL" for s in collecting_exporter.spans)
+
+    @pytest.mark.asyncio
+    async def test_span_has_llm_kind(
+        self, tracer, collecting_exporter, google_client
+    ):
+        chunk = make_google_stream_chunk(text="Hi")
+        google_client.aio.models.generate_content_stream = make_async_stream(chunk)
+        wrap_generate_content_stream_async(google_client)
+        async for _ in google_client.aio.models.generate_content_stream(
+            model="gemini-2.0-flash", contents="hello"
+        ):
+            pass
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "GOOGLE_API_CALL"
+        )
+        assert span.attributes.get(AttributeKeys.JUDGMENT_SPAN_KIND) == "llm"
+
+    @pytest.mark.asyncio
+    async def test_accumulates_text_across_chunks(
+        self, tracer, collecting_exporter, google_client
+    ):
+        google_client.aio.models.generate_content_stream = make_async_stream(
+            make_google_stream_chunk(text="Hello "),
+            make_google_stream_chunk(text="world"),
+            make_google_stream_chunk(text=None, prompt_tokens=8, completion_tokens=2),
+        )
+        wrap_generate_content_stream_async(google_client)
+        async for _ in google_client.aio.models.generate_content_stream(
+            model="gemini-2.0-flash", contents="hello"
+        ):
+            pass
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "GOOGLE_API_CALL"
+        )
+        assert span.attributes.get(AttributeKeys.GEN_AI_COMPLETION) == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_records_token_usage_from_final_chunk(
+        self, tracer, collecting_exporter, google_client
+    ):
+        google_client.aio.models.generate_content_stream = make_async_stream(
+            make_google_stream_chunk(text="A"),
+            make_google_stream_chunk(text="B", prompt_tokens=15, completion_tokens=7),
+        )
+        wrap_generate_content_stream_async(google_client)
+        async for _ in google_client.aio.models.generate_content_stream(
+            model="gemini-2.0-flash", contents="hello"
+        ):
+            pass
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "GOOGLE_API_CALL"
+        )
+        assert (
+            span.attributes.get(AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS)
+            == 15
+        )
+        assert span.attributes.get(AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS) == 7
+
+    @pytest.mark.asyncio
+    async def test_chunks_without_text_not_accumulated(
+        self, tracer, collecting_exporter, google_client
+    ):
+        google_client.aio.models.generate_content_stream = make_async_stream(
+            make_google_stream_chunk(text=None),
+            make_google_stream_chunk(text="Only this"),
+        )
+        wrap_generate_content_stream_async(google_client)
+        async for _ in google_client.aio.models.generate_content_stream(
+            model="gemini-2.0-flash", contents="hello"
+        ):
+            pass
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "GOOGLE_API_CALL"
+        )
+        assert span.attributes.get(AttributeKeys.GEN_AI_COMPLETION) == "Only this"
+
+    @pytest.mark.asyncio
+    async def test_error_sets_error_status(
+        self, tracer, collecting_exporter, google_client
+    ):
+        async def failing_stream(**kwargs):
+            yield make_google_stream_chunk(text="A")
+            raise RuntimeError("stream failed")
+
+        google_client.aio.models.generate_content_stream = failing_stream
+        wrap_generate_content_stream_async(google_client)
+        with pytest.raises(RuntimeError):
+            async for _ in google_client.aio.models.generate_content_stream(
+                model="gemini-2.0-flash", contents="hello"
+            ):
+                pass
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "GOOGLE_API_CALL"
+        )
+        assert span.status.status_code.name == "ERROR"
+
+    @pytest.mark.asyncio
+    async def test_wrap_replaces_method(self, tracer, google_client):
+        original = google_client.aio.models.generate_content_stream
+        google_client.aio.models.generate_content_stream = make_async_stream(
+            make_google_stream_chunk(text="hi")
+        )
+        wrap_generate_content_stream_async(google_client)
+        assert google_client.aio.models.generate_content_stream is not original
+
+    @pytest.mark.asyncio
+    async def test_yields_all_chunks_unchanged(self, tracer, google_client):
+        chunk1 = make_google_stream_chunk(text="A")
+        chunk2 = make_google_stream_chunk(text="B")
+        google_client.aio.models.generate_content_stream = make_async_stream(
+            chunk1, chunk2
+        )
+        wrap_generate_content_stream_async(google_client)
+        result = [
+            chunk
+            async for chunk in google_client.aio.models.generate_content_stream(
+                model="gemini-2.0-flash", contents="hello"
+            )
+        ]
+        assert result == [chunk1, chunk2]


### PR DESCRIPTION
## Summary

Extends the Google GenAI instrumentation to cover `client.aio.models.generate_content_stream` — the **async iterator** variant of the streaming API. Before this PR, only the non-streaming `client.models.generate_content` path was instrumented; async streaming calls produced no spans.

**Changes:**
- `generate_content.py`: adds `wrap_generate_content_stream_async` using `immutable_wrap_async_iterator`, with `pre_hook` / `yield_hook` / `error_hook` / `finally_hook` that mirror the patterns already used for OpenAI and Anthropic async streaming. Also extracts `_process_google_stream_chunk` and `_flush_stream_span` helpers (shared logic between this and the analogous sync streaming PR #760).
- `wrapper.py`: `wrap_google_client` now calls `wrap_generate_content_stream_async` in addition to `wrap_generate_content_sync`, so a single client wrap covers all three Google API paths.
- `test_generate_content_stream_async.py`: 8 unit tests covering span creation, `llm` span kind, multi-chunk text accumulation, token-usage recording from the final chunk, error status propagation, method replacement, and passthrough of unchanged chunk objects.

## Relationship to PR #760

PR #760 adds `wrap_generate_content_stream_sync` for `client.models.generate_content_stream` (sync iterator). This PR targets the async counterpart `client.aio.models.generate_content_stream` and is independent of #760 at the code level (different API path). If both merge, the `_process_google_stream_chunk` helper will need a minor reconciliation — happy to rebase onto #760 once it lands if that's easier.

## Test plan

```bash
pytest src/tests/instrumentation/llm/google/test_generate_content_stream_async.py -v
```

All 8 tests cover:
- [ ] Span is created with name `GOOGLE_API_CALL`
- [ ] Span kind attribute is `llm`
- [ ] Text chunks are accumulated across multiple yields
- [ ] Token usage is recorded from the final (usage-bearing) chunk
- [ ] Chunks with `text=None` are skipped in accumulation
- [ ] Stream errors set span status to `ERROR`
- [ ] `wrap_generate_content_stream_async` replaces the original method
- [ ] All yielded chunks pass through unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval/pull/768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->