### PR TITLE
feat(jql): scope SDK queries by session

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,17 @@ rest of Judgeval. Tenant identifiers are not part of the query payload.
 
 ```python
 from judgeval import Judgeval
-from judgeval.jql import eq, traces
+from judgeval.jql import spans
 
 client = Judgeval(project_name="my-project")
-result = client.query(traces().where(eq("session", "session-123")).ids())
+result = client.query(spans().rows(), session_ids=["session-123"])
 ```
+
+`session_ids` is outside the JQL query object. Judgment resolves the sessions
+within the authenticated organization and project, then narrows every part of
+the query to their traces. If none resolve, the request fails instead of
+falling back to the whole project. The same option works with `present()` and
+`discover()`.
 
 ## Integrations
 

--- a/scripts/jql_contract/public-openapi.json
+++ b/scripts/jql_contract/public-openapi.json
@@ -270,27 +270,32 @@
         "additionalProperties": false,
         "$id": "PublicJqlRequest",
         "type": "object",
-        "required": [
-          "query"
-        ],
+        "required": ["query"],
         "properties": {
           "query": {},
           "limit": {
             "minimum": 1,
             "maximum": 10000,
             "type": "integer"
+          },
+          "session_ids": {
+            "minItems": 1,
+            "maxItems": 1000,
+            "description": "Sessions to resolve to a trace-scoped query within the authenticated organization and project.",
+            "type": "array",
+            "items": {
+              "minLength": 1,
+              "maxLength": 512,
+              "pattern": ".*\\S.*",
+              "type": "string"
+            }
           }
         }
       },
       "PublicJqlQueryResponse": {
         "$id": "PublicJqlQueryResponse",
         "type": "object",
-        "required": [
-          "query_id",
-          "rows",
-          "row_count",
-          "elapsed_ms"
-        ],
+        "required": ["query_id", "rows", "row_count", "elapsed_ms"],
         "properties": {
           "query_id": {
             "type": "string"
@@ -331,12 +336,7 @@
       "PublicJqlPresentationResponse": {
         "$id": "PublicJqlPresentationResponse",
         "type": "object",
-        "required": [
-          "query_id",
-          "presentation",
-          "frame",
-          "elapsed_ms"
-        ],
+        "required": ["query_id", "presentation", "frame", "elapsed_ms"],
         "properties": {
           "query_id": {
             "type": "string"
@@ -359,10 +359,7 @@
       "PublicJqlErrorResponse": {
         "$id": "PublicJqlErrorResponse",
         "type": "object",
-        "required": [
-          "error",
-          "message"
-        ],
+        "required": ["error", "message"],
         "properties": {
           "error": {
             "type": "string"

--- a/src/judgeval/judgeval.py
+++ b/src/judgeval/judgeval.py
@@ -192,29 +192,48 @@ class Judgeval:
         )
 
     def query(
-        self, query: "QueryInput", *, limit: Optional[int] = None
+        self,
+        query: "QueryInput",
+        *,
+        limit: Optional[int] = None,
+        session_ids: Optional[Sequence[str]] = None,
     ) -> "JqlQueryResponse":
-        """Run a structured, tenant-scoped JQL query for this project."""
+        """Run JQL for this project, optionally narrowed by session IDs."""
         from judgeval.jql import to_json
 
-        return cast("JqlQueryResponse", self._run_jql("query", to_json(query), limit))
+        return cast(
+            "JqlQueryResponse",
+            self._run_jql("query", to_json(query), limit, session_ids),
+        )
 
     def present(
-        self, query: "QueryInput", *, limit: Optional[int] = None
+        self,
+        query: "QueryInput",
+        *,
+        limit: Optional[int] = None,
+        session_ids: Optional[Sequence[str]] = None,
     ) -> "JqlPresentationResponse":
-        """Run a chart or table JQL query for this project."""
+        """Run a chart or table JQL query, optionally narrowed by session."""
         from judgeval.jql import to_json
 
         return cast(
             "JqlPresentationResponse",
-            self._run_jql("query/presentation", to_json(query), limit),
+            self._run_jql("query/presentation", to_json(query), limit, session_ids),
         )
 
-    def _run_jql(self, path: str, query: Dict[str, Any], limit: Optional[int]) -> Any:
+    def _run_jql(
+        self,
+        path: str,
+        query: Dict[str, Any],
+        limit: Optional[int],
+        session_ids: Optional[Sequence[str]],
+    ) -> Any:
         project_id = self._require_jql_project_id()
         payload: Dict[str, Any] = {"query": query}
         if limit is not None:
             payload["limit"] = limit
+        if session_ids is not None:
+            payload["session_ids"] = list(session_ids)
         try:
             return self._internal_client._request(
                 "POST",
@@ -232,12 +251,15 @@ class Judgeval:
         kind: "DiscoveryKind",
         *,
         limit: Optional[int] = None,
+        session_ids: Optional[Sequence[str]] = None,
         **options: Any,
     ) -> "JqlQueryResponse":
         """Discover project-scoped judges, fields, models, and related values."""
         from judgeval.jql import discovery
 
-        return self.query(discovery(kind, **options), limit=limit)
+        return self.query(
+            discovery(kind, **options), limit=limit, session_ids=session_ids
+        )
 
     def _require_jql_project_id(self) -> str:
         if not self._project_id:

--- a/src/tests/jql/test_session_scope.py
+++ b/src/tests/jql/test_session_scope.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+
+from judgeval import Judgeval
+from judgeval.internal.api.api_client import JudgmentSyncClient
+from judgeval.jql import spans
+
+
+def test_judgeval_query_sends_session_scope_outside_jql(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("judgeval.judgeval.resolve_project_id", lambda *_: "project-1")
+    calls = []
+
+    def fake_request(self, method, url, payload, params=None):  # type: ignore[no-untyped-def]
+        calls.append((method, url, payload, params))
+        return {
+            "query_id": "q-1",
+            "rows": [{"span_id": "span-1"}],
+            "row_count": 1,
+            "elapsed_ms": 4,
+        }
+
+    monkeypatch.setattr(JudgmentSyncClient, "_request", fake_request)
+    client = Judgeval(
+        project_name="demo",
+        api_key="api-key",
+        organization_id="org-1",
+        api_url="https://api.example.com/",
+    )
+
+    response = client.query(spans().rows(), session_ids=["session-1"])
+
+    assert {"calls": calls, "response": response} == {
+        "calls": [
+            (
+                "POST",
+                "https://api.example.com/v1/projects/project-1/query",
+                {
+                    "query": {
+                        "op": "query",
+                        "source": "spans",
+                        "select": {"op": "rows"},
+                    },
+                    "session_ids": ["session-1"],
+                },
+                None,
+            )
+        ],
+        "response": {
+            "query_id": "q-1",
+            "rows": [{"span_id": "span-1"}],
+            "row_count": 1,
+            "elapsed_ms": 4,
+        },
+    }


### PR DESCRIPTION
## Summary

- add `session_ids` to `query`, `present`, and `discover`
- serialize session scope outside canonical JQL JSON in the public request envelope
- refresh the public transport snapshot and document session-scoped span queries
- add an exact full-value transport test

## Testing

- `uv run pytest src/tests/jql -q`
- `uv run mypy src/judgeval/judgeval.py`
- `uv run ruff check src/judgeval/judgeval.py src/tests/jql/test_session_scope.py`
- `uv run ruff format --check src/judgeval/judgeval.py src/tests/jql/test_session_scope.py`

## Rollout

Depends on JudgmentLabs/judgment-mono#3539. Merge and deploy the public JQL gateway before releasing this SDK change.