### PR TITLE
feat(jql): add query scoping and offline sources

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
         run: |
           git diff --exit-code -- \
             src/judgeval/jql/_generated_contract.py \
+            src/judgeval/jql/_generated_roots.py \
             src/judgeval/jql/_generated_transport.py
 
       - name: Build distributions
@@ -82,6 +83,7 @@ jobs:
         run: |
           git diff --exit-code -- \
             src/judgeval/jql/_generated_contract.py \
+            src/judgeval/jql/_generated_roots.py \
             src/judgeval/jql/_generated_transport.py
 
   run-tests:

--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -66,6 +66,7 @@ jobs:
             ../judgment-mono/services/judgeval-server/openapi.public-jql.json
           git diff --exit-code -- \
             src/judgeval/jql/_generated_contract.py \
+            src/judgeval/jql/_generated_roots.py \
             src/judgeval/jql/_generated_transport.py
 
       - name: Create new tag

--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -43,6 +43,7 @@ jobs:
             ../judgment-mono/services/judgeval-server/openapi.public-jql.json
           git diff --exit-code -- \
             src/judgeval/jql/_generated_contract.py \
+            src/judgeval/jql/_generated_roots.py \
             src/judgeval/jql/_generated_transport.py
 
       - name: Get latest version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,7 @@ jobs:
             ../judgment-mono/services/judgeval-server/openapi.public-jql.json
           git diff --exit-code -- \
             src/judgeval/jql/_generated_contract.py \
+            src/judgeval/jql/_generated_roots.py \
             src/judgeval/jql/_generated_transport.py
 
       - name: Get latest version

--- a/README.md
+++ b/README.md
@@ -85,11 +85,17 @@ rest of Judgeval. Tenant identifiers are not part of the query payload.
 
 ```python
 from judgeval import Judgeval
-from judgeval.jql import eq, traces
+from judgeval.jql import spans
 
 client = Judgeval(project_name="my-project")
-result = client.query(traces().where(eq("session", "session-123")).ids())
+result = client.query(spans().rows(), session_ids=["session-123"])
 ```
+
+`session_ids` is outside the JQL query object. Judgment resolves the sessions
+within the authenticated organization and project, then narrows every part of
+the query to their traces. If none resolve, the request fails instead of
+falling back to the whole project. The same option works with `present()` and
+`discover()`.
 
 ## Integrations
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ the query to their traces. If no session resolves, the request fails instead of
 falling back to the whole project. Both options work with `present()` and
 `discover()`.
 
+Use `offline_traces()` or `offline_spans()` to query traces captured by an
+offline test:
+
+```python
+from judgeval.jql import offline_traces
+
+offline_result = client.query(offline_traces().rows())
+```
+
 ## Integrations
 
 Supports OpenAI, Anthropic, Google GenAI, Together AI, LangGraph, OpenLit, and Claude Agent SDK. See the full [integrations docs](https://docs.judgmentlabs.ai/documentation/integrations/introduction).

--- a/README.md
+++ b/README.md
@@ -88,13 +88,14 @@ from judgeval import Judgeval
 from judgeval.jql import spans
 
 client = Judgeval(project_name="my-project")
-result = client.query(spans().rows(), session_ids=["session-123"])
+result = client.query(spans().rows(), trace_ids=["trace-123"])
 ```
 
-`session_ids` is outside the JQL query object. Judgment resolves the sessions
+`trace_ids` and `session_ids` are mutually exclusive options outside the JQL
+query object. Trace IDs narrow the query directly. Judgment resolves session IDs
 within the authenticated organization and project, then narrows every part of
-the query to their traces. If none resolve, the request fails instead of
-falling back to the whole project. The same option works with `present()` and
+the query to their traces. If no session resolves, the request fails instead of
+falling back to the whole project. Both options work with `present()` and
 `discover()`.
 
 ## Integrations

--- a/scripts/generate_jql.py
+++ b/scripts/generate_jql.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import keyword
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -13,6 +14,7 @@ ROOT = Path(__file__).resolve().parents[1]
 CONTRACT_DIR = ROOT / "scripts" / "jql_contract"
 OUTPUTS = (
     ROOT / "src" / "judgeval" / "jql" / "_generated_contract.py",
+    ROOT / "src" / "judgeval" / "jql" / "_generated_roots.py",
     ROOT / "src" / "judgeval" / "jql" / "_generated_transport.py",
 )
 ROOT_SCHEMAS = (
@@ -138,11 +140,17 @@ def generate(dal_document: dict[str, Any], public_document: dict[str, Any]) -> N
     schemas = jql_contract["components"]["schemas"]
     entries = {item["op"] for node in walk(schemas) for item in node.get("x-jql", [])}
     discovery_kinds = schemas["DiscoveryQuery"]["properties"]["kind"]["enum"]
+    query_sources = schemas["SourceQuery"]["properties"]["source"]["enum"]
 
     operation_members = "\n".join(
         f"    {json.dumps(operation)}," for operation in sorted(entries)
     )
-    literal_members = "\n".join(f"    {json.dumps(kind)}," for kind in discovery_kinds)
+    discovery_kind_members = "\n".join(
+        f"    {json.dumps(kind)}," for kind in discovery_kinds
+    )
+    query_source_members = "\n".join(
+        f"    {json.dumps(source)}," for source in query_sources
+    )
     contract_source = f'''"""Generated from DAL OpenAPI x-jql metadata; do not edit."""
 
 from typing import Literal
@@ -150,11 +158,53 @@ from typing import Literal
 SUPPORTED_OPS = (
 {operation_members}
 )
+QUERY_SOURCES = (
+{query_source_members}
+)
+QuerySource = Literal[
+{query_source_members}
+]
 DiscoveryKind = Literal[
-{literal_members}
+{discovery_kind_members}
 ]
 '''
     OUTPUTS[0].write_text(contract_source, encoding="utf-8", newline="\n")
+
+    invalid_sources = [
+        source
+        for source in query_sources
+        if not source.isidentifier() or keyword.iskeyword(source)
+    ]
+    if invalid_sources:
+        raise ValueError(
+            f"JQL query sources must be valid Python identifiers: {invalid_sources!r}"
+        )
+    root_functions = "\n\n\n".join(
+        f"""def {source}(filter: Optional[Filter] = None) -> QueryBuilder:
+    from judgeval.jql import _query
+
+    return _query({json.dumps(source)}, filter)"""
+        for source in query_sources
+    )
+    root_exports = "\n".join(f'    "{source}",' for source in query_sources)
+    roots_source = f'''"""Generated from DAL OpenAPI query sources; do not edit."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from judgeval.jql import Filter, QueryBuilder
+
+
+{root_functions}
+
+
+__all__ = [
+{root_exports}
+]
+'''
+    OUTPUTS[1].write_text(roots_source, encoding="utf-8", newline="\n")
 
     public_schemas = public_document["components"]["schemas"]
     classes = [
@@ -169,7 +219,7 @@ DiscoveryKind = Literal[
         or (name == "Any" and "Any" in class_source)
         or f"{name}[" in class_source
     ]
-    OUTPUTS[1].write_text(
+    OUTPUTS[2].write_text(
         '"""Generated from Judgeval public JQL OpenAPI; do not edit."""\n\n'
         f"from typing import {', '.join(typing_names)}\n\n\n" + class_source + "\n",
         encoding="utf-8",
@@ -177,7 +227,7 @@ DiscoveryKind = Literal[
     )
     print(
         f"Generated {OUTPUTS[0]} with {len(entries)} canonical JQL operations and "
-        f"{OUTPUTS[1]}."
+        f"{OUTPUTS[1]} with {len(query_sources)} query roots and {OUTPUTS[2]}."
     )
 
 

--- a/scripts/jql_contract/README.md
+++ b/scripts/jql_contract/README.md
@@ -6,9 +6,10 @@ These files are public-safe snapshots of the canonical JQL contracts in
 - `jql-ir.openapi.json` contains only the public JQL IR schema-reference closure.
 - `public-openapi.json` is judgeval-server's public JQL transport contract.
 
-Python package builds regenerate the checked-in modules under
-`src/judgeval/jql` from these snapshots. Pull-request and release CI separately
-regenerate from `judgment-mono/main` and fail if the Python SDK output differs.
+Python package builds regenerate the checked-in contract, query-root, and
+transport modules under `src/judgeval/jql` from these snapshots. Pull-request
+and release CI separately regenerate from `judgment-mono/main` and fail if the
+Python SDK output differs.
 
 After an intentional upstream contract change, refresh the snapshots with:
 

--- a/scripts/jql_contract/jql-ir.openapi.json
+++ b/scripts/jql_contract/jql-ir.openapi.json
@@ -228,7 +228,9 @@
             "enum": [
               "traces",
               "spans",
-              "sessions"
+              "sessions",
+              "offline_traces",
+              "offline_spans"
             ],
             "title": "Source",
             "type": "string"
@@ -257,7 +259,9 @@
             "dsl": [
               "traces",
               "spans",
-              "sessions"
+              "sessions",
+              "offline_traces",
+              "offline_spans"
             ],
             "example": "traces({ filter: status('error') }).last('7d').ids()",
             "lang": "proj.traces(pred)",
@@ -343,7 +347,7 @@
         "x-jql": [
           {
             "category": "filter",
-            "doc": "span name \u2014 span grain",
+            "doc": "span name \u2014 the root's at traces/sessions",
             "example": "name('agent.run')",
             "lang": "name(\"agent.run\")",
             "model": "NameFilter",
@@ -476,7 +480,7 @@
         "x-jql": [
           {
             "category": "filter",
-            "doc": "span cost \u2014 span grain",
+            "doc": "cost in USD \u2014 per span, summed at traces/sessions",
             "example": "cost({ gt: 0.01 })",
             "lang": "cost(gt=0.01)",
             "model": "CostFilter",
@@ -567,9 +571,9 @@
         "x-jql": [
           {
             "category": "filter",
-            "doc": "duration in ms",
-            "example": "duration({ gte: 1000 })",
-            "lang": "duration(gte=1000)",
+            "doc": "duration in nanoseconds",
+            "example": "duration({ gte: 1_000_000_000 })",
+            "lang": "duration(gte=1_000_000_000)",
             "model": "DurationFilter",
             "op": "duration",
             "ts": {
@@ -3377,6 +3381,7 @@
               "params": [
                 {
                   "name": "by",
+                  "optional": true,
                   "ts_type": "string | BucketExpr | (string | BucketExpr)[] | undefined",
                   "wire": "by"
                 },
@@ -3467,7 +3472,7 @@
         "x-jql": [
           {
             "category": "stage",
-            "doc": "order the rows",
+            "doc": "order rows; append ` desc` for descending",
             "dsl": [
               "sort"
             ],
@@ -4122,7 +4127,10 @@
               {
                 "enum": [
                   "traces",
-                  "spans"
+                  "spans",
+                  "sessions",
+                  "offline_traces",
+                  "offline_spans"
                 ],
                 "type": "string"
               },
@@ -4202,7 +4210,7 @@
               ],
               [
                 "fields",
-                "standard fields usable for filters, groups, and aggregates",
+                "standard fields, each carrying the operations it supports at that source",
                 "`source` (required), `limit`"
               ],
               [

--- a/scripts/jql_contract/public-openapi.json
+++ b/scripts/jql_contract/public-openapi.json
@@ -278,6 +278,18 @@
             "maximum": 10000,
             "type": "integer"
           },
+          "trace_ids": {
+            "minItems": 1,
+            "maxItems": 1000,
+            "description": "Traces to bind directly to the query within the authenticated organization and project.",
+            "type": "array",
+            "items": {
+              "minLength": 1,
+              "maxLength": 512,
+              "pattern": ".*\\S.*",
+              "type": "string"
+            }
+          },
           "session_ids": {
             "minItems": 1,
             "maxItems": 1000,

--- a/scripts/jql_contract/public-openapi.json
+++ b/scripts/jql_contract/public-openapi.json
@@ -270,27 +270,32 @@
         "additionalProperties": false,
         "$id": "PublicJqlRequest",
         "type": "object",
-        "required": [
-          "query"
-        ],
+        "required": ["query"],
         "properties": {
           "query": {},
           "limit": {
             "minimum": 1,
             "maximum": 10000,
             "type": "integer"
+          },
+          "session_ids": {
+            "minItems": 1,
+            "maxItems": 1000,
+            "description": "Sessions to resolve to a trace-scoped query within the authenticated organization and project.",
+            "type": "array",
+            "items": {
+              "minLength": 1,
+              "maxLength": 512,
+              "pattern": ".*\\S.*",
+              "type": "string"
+            }
           }
         }
       },
       "PublicJqlQueryResponse": {
         "$id": "PublicJqlQueryResponse",
         "type": "object",
-        "required": [
-          "query_id",
-          "rows",
-          "row_count",
-          "elapsed_ms"
-        ],
+        "required": ["query_id", "rows", "row_count", "elapsed_ms"],
         "properties": {
           "query_id": {
             "type": "string"
@@ -331,12 +336,7 @@
       "PublicJqlPresentationResponse": {
         "$id": "PublicJqlPresentationResponse",
         "type": "object",
-        "required": [
-          "query_id",
-          "presentation",
-          "frame",
-          "elapsed_ms"
-        ],
+        "required": ["query_id", "presentation", "frame", "elapsed_ms"],
         "properties": {
           "query_id": {
             "type": "string"
@@ -359,10 +359,7 @@
       "PublicJqlErrorResponse": {
         "$id": "PublicJqlErrorResponse",
         "type": "object",
-        "required": [
-          "error",
-          "message"
-        ],
+        "required": ["error", "message"],
         "properties": {
           "error": {
             "type": "string"

--- a/scripts/jql_contract/public-openapi.json
+++ b/scripts/jql_contract/public-openapi.json
@@ -270,7 +270,9 @@
         "additionalProperties": false,
         "$id": "PublicJqlRequest",
         "type": "object",
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "properties": {
           "query": {},
           "limit": {
@@ -281,7 +283,7 @@
           "trace_ids": {
             "minItems": 1,
             "maxItems": 1000,
-            "description": "Traces to bind directly to the query within the authenticated organization and project.",
+            "description": "Traces to bind directly to the query within the authenticated organization and project. Use offline trace IDs for offline query sources.",
             "type": "array",
             "items": {
               "minLength": 1,
@@ -293,7 +295,7 @@
           "session_ids": {
             "minItems": 1,
             "maxItems": 1000,
-            "description": "Sessions to resolve to a trace-scoped query within the authenticated organization and project.",
+            "description": "Live sessions to resolve to a trace-scoped query within the authenticated organization and project. Unavailable for offline query sources.",
             "type": "array",
             "items": {
               "minLength": 1,
@@ -307,7 +309,12 @@
       "PublicJqlQueryResponse": {
         "$id": "PublicJqlQueryResponse",
         "type": "object",
-        "required": ["query_id", "rows", "row_count", "elapsed_ms"],
+        "required": [
+          "query_id",
+          "rows",
+          "row_count",
+          "elapsed_ms"
+        ],
         "properties": {
           "query_id": {
             "type": "string"
@@ -348,7 +355,12 @@
       "PublicJqlPresentationResponse": {
         "$id": "PublicJqlPresentationResponse",
         "type": "object",
-        "required": ["query_id", "presentation", "frame", "elapsed_ms"],
+        "required": [
+          "query_id",
+          "presentation",
+          "frame",
+          "elapsed_ms"
+        ],
         "properties": {
           "query_id": {
             "type": "string"
@@ -371,7 +383,10 @@
       "PublicJqlErrorResponse": {
         "$id": "PublicJqlErrorResponse",
         "type": "object",
-        "required": ["error", "message"],
+        "required": [
+          "error",
+          "message"
+        ],
         "properties": {
           "error": {
             "type": "string"

--- a/src/judgeval/jql/__init__.py
+++ b/src/judgeval/jql/__init__.py
@@ -18,7 +18,14 @@ from typing import (
     Union,
 )
 
-from judgeval.jql._generated_contract import DiscoveryKind, SUPPORTED_OPS
+from judgeval.jql._generated_contract import DiscoveryKind, QuerySource, SUPPORTED_OPS
+from judgeval.jql._generated_roots import (
+    offline_spans,
+    offline_traces,
+    sessions,
+    spans,
+    traces,
+)
 from judgeval.jql._generated_transport import (
     JqlPresentationResponse,
     JqlQueryResponse,
@@ -549,9 +556,7 @@ class PipelineBuilder:
         return PipelineBuilder(self._spec, (*self._stages, deepcopy(stage)))
 
 
-def _query(
-    source: Literal["traces", "spans", "sessions"], filter: Optional[Filter]
-) -> QueryBuilder:
+def _query(source: QuerySource, filter: Optional[Filter]) -> QueryBuilder:
     return QueryBuilder(
         _compact(
             _node(
@@ -563,18 +568,6 @@ def _query(
             )
         )
     )
-
-
-def traces(filter: Optional[Filter] = None) -> QueryBuilder:
-    return _query("traces", filter)
-
-
-def spans(filter: Optional[Filter] = None) -> QueryBuilder:
-    return _query("spans", filter)
-
-
-def sessions(filter: Optional[Filter] = None) -> QueryBuilder:
-    return _query("sessions", filter)
 
 
 def discovery(kind: DiscoveryKind, **options: Any) -> JsonObject:
@@ -610,6 +603,7 @@ __all__ = [
     "PresentationField",
     "QueryBuilder",
     "QueryInput",
+    "QuerySource",
     "agg_expr",
     "all_",
     "ancestor_of",
@@ -642,6 +636,8 @@ __all__ = [
     "no_span",
     "no_trace",
     "not_",
+    "offline_spans",
+    "offline_traces",
     "over_scores",
     "over_spans",
     "over_traces",

--- a/src/judgeval/jql/_generated_contract.py
+++ b/src/judgeval/jql/_generated_contract.py
@@ -59,6 +59,20 @@ SUPPORTED_OPS = (
     "trend",
     "where",
 )
+QUERY_SOURCES = (
+    "traces",
+    "spans",
+    "sessions",
+    "offline_traces",
+    "offline_spans",
+)
+QuerySource = Literal[
+    "traces",
+    "spans",
+    "sessions",
+    "offline_traces",
+    "offline_spans",
+]
 DiscoveryKind = Literal[
     "judges",
     "behaviors",

--- a/src/judgeval/jql/_generated_roots.py
+++ b/src/judgeval/jql/_generated_roots.py
@@ -1,0 +1,47 @@
+"""Generated from DAL OpenAPI query sources; do not edit."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from judgeval.jql import Filter, QueryBuilder
+
+
+def traces(filter: Optional[Filter] = None) -> QueryBuilder:
+    from judgeval.jql import _query
+
+    return _query("traces", filter)
+
+
+def spans(filter: Optional[Filter] = None) -> QueryBuilder:
+    from judgeval.jql import _query
+
+    return _query("spans", filter)
+
+
+def sessions(filter: Optional[Filter] = None) -> QueryBuilder:
+    from judgeval.jql import _query
+
+    return _query("sessions", filter)
+
+
+def offline_traces(filter: Optional[Filter] = None) -> QueryBuilder:
+    from judgeval.jql import _query
+
+    return _query("offline_traces", filter)
+
+
+def offline_spans(filter: Optional[Filter] = None) -> QueryBuilder:
+    from judgeval.jql import _query
+
+    return _query("offline_spans", filter)
+
+
+__all__ = [
+    "traces",
+    "spans",
+    "sessions",
+    "offline_traces",
+    "offline_spans",
+]

--- a/src/judgeval/judgeval.py
+++ b/src/judgeval/judgeval.py
@@ -196,14 +196,15 @@ class Judgeval:
         query: "QueryInput",
         *,
         limit: Optional[int] = None,
+        trace_ids: Optional[Sequence[str]] = None,
         session_ids: Optional[Sequence[str]] = None,
     ) -> "JqlQueryResponse":
-        """Run JQL for this project, optionally narrowed by session IDs."""
+        """Run JQL for this project, optionally narrowed by trace or session IDs."""
         from judgeval.jql import to_json
 
         return cast(
             "JqlQueryResponse",
-            self._run_jql("query", to_json(query), limit, session_ids),
+            self._run_jql("query", to_json(query), limit, trace_ids, session_ids),
         )
 
     def present(
@@ -211,14 +212,17 @@ class Judgeval:
         query: "QueryInput",
         *,
         limit: Optional[int] = None,
+        trace_ids: Optional[Sequence[str]] = None,
         session_ids: Optional[Sequence[str]] = None,
     ) -> "JqlPresentationResponse":
-        """Run a chart or table JQL query, optionally narrowed by session."""
+        """Run a chart or table JQL query, optionally narrowed by trace or session IDs."""
         from judgeval.jql import to_json
 
         return cast(
             "JqlPresentationResponse",
-            self._run_jql("query/presentation", to_json(query), limit, session_ids),
+            self._run_jql(
+                "query/presentation", to_json(query), limit, trace_ids, session_ids
+            ),
         )
 
     def _run_jql(
@@ -226,12 +230,17 @@ class Judgeval:
         path: str,
         query: Dict[str, Any],
         limit: Optional[int],
+        trace_ids: Optional[Sequence[str]],
         session_ids: Optional[Sequence[str]],
     ) -> Any:
+        if trace_ids is not None and session_ids is not None:
+            raise ValueError("trace_ids and session_ids are mutually exclusive")
         project_id = self._require_jql_project_id()
         payload: Dict[str, Any] = {"query": query}
         if limit is not None:
             payload["limit"] = limit
+        if trace_ids is not None:
+            payload["trace_ids"] = list(trace_ids)
         if session_ids is not None:
             payload["session_ids"] = list(session_ids)
         try:
@@ -251,6 +260,7 @@ class Judgeval:
         kind: "DiscoveryKind",
         *,
         limit: Optional[int] = None,
+        trace_ids: Optional[Sequence[str]] = None,
         session_ids: Optional[Sequence[str]] = None,
         **options: Any,
     ) -> "JqlQueryResponse":
@@ -258,7 +268,10 @@ class Judgeval:
         from judgeval.jql import discovery
 
         return self.query(
-            discovery(kind, **options), limit=limit, session_ids=session_ids
+            discovery(kind, **options),
+            limit=limit,
+            trace_ids=trace_ids,
+            session_ids=session_ids,
         )
 
     def _require_jql_project_id(self) -> str:

--- a/src/judgeval/judgeval.py
+++ b/src/judgeval/judgeval.py
@@ -192,29 +192,48 @@ class Judgeval:
         )
 
     def query(
-        self, query: "QueryInput", *, limit: Optional[int] = None
+        self,
+        query: "QueryInput",
+        *,
+        limit: Optional[int] = None,
+        session_ids: Optional[Sequence[str]] = None,
     ) -> "JqlQueryResponse":
-        """Run a structured, tenant-scoped JQL query for this project."""
+        """Run JQL for this project, optionally narrowed by session IDs."""
         from judgeval.jql import to_json
 
-        return cast("JqlQueryResponse", self._run_jql("query", to_json(query), limit))
+        return cast(
+            "JqlQueryResponse",
+            self._run_jql("query", to_json(query), limit, session_ids),
+        )
 
     def present(
-        self, query: "QueryInput", *, limit: Optional[int] = None
+        self,
+        query: "QueryInput",
+        *,
+        limit: Optional[int] = None,
+        session_ids: Optional[Sequence[str]] = None,
     ) -> "JqlPresentationResponse":
-        """Run a chart or table JQL query for this project."""
+        """Run a chart or table JQL query, optionally narrowed by session."""
         from judgeval.jql import to_json
 
         return cast(
             "JqlPresentationResponse",
-            self._run_jql("query/presentation", to_json(query), limit),
+            self._run_jql("query/presentation", to_json(query), limit, session_ids),
         )
 
-    def _run_jql(self, path: str, query: Dict[str, Any], limit: Optional[int]) -> Any:
+    def _run_jql(
+        self,
+        path: str,
+        query: Dict[str, Any],
+        limit: Optional[int],
+        session_ids: Optional[Sequence[str]],
+    ) -> Any:
         project_id = self._require_jql_project_id()
         payload: Dict[str, Any] = {"query": query}
         if limit is not None:
             payload["limit"] = limit
+        if session_ids is not None:
+            payload["session_ids"] = list(session_ids)
         try:
             return self._internal_client._request(
                 "POST",
@@ -232,12 +251,15 @@ class Judgeval:
         kind: "DiscoveryKind",
         *,
         limit: Optional[int] = None,
+        session_ids: Optional[Sequence[str]] = None,
         **options: Any,
     ) -> "JqlQueryResponse":
         """Discover project-scoped judges, fields, models, and related values."""
         from judgeval.jql import discovery
 
-        return self.query(discovery(kind, **options), limit=limit)
+        return self.query(
+            discovery(kind, **options), limit=limit, session_ids=session_ids
+        )
 
     def _require_jql_project_id(self) -> str:
         if not self._project_id:

--- a/src/tests/jql/test_offline_sources.py
+++ b/src/tests/jql/test_offline_sources.py
@@ -1,0 +1,30 @@
+from judgeval.jql import offline_spans, offline_traces
+from judgeval.jql._generated_contract import QUERY_SOURCES
+
+
+def test_generated_query_sources_cover_every_public_root() -> None:
+    assert QUERY_SOURCES == (
+        "traces",
+        "spans",
+        "sessions",
+        "offline_traces",
+        "offline_spans",
+    )
+
+
+def test_offline_roots_emit_canonical_json() -> None:
+    assert [
+        offline_traces().rows().to_json(),
+        offline_spans().rows().to_json(),
+    ] == [
+        {
+            "op": "query",
+            "source": "offline_traces",
+            "select": {"op": "rows"},
+        },
+        {
+            "op": "query",
+            "source": "offline_spans",
+            "select": {"op": "rows"},
+        },
+    ]

--- a/src/tests/jql/test_session_scope.py
+++ b/src/tests/jql/test_session_scope.py
@@ -7,8 +7,17 @@ from judgeval.internal.api.api_client import JudgmentSyncClient
 from judgeval.jql import spans
 
 
-def test_judgeval_query_sends_session_scope_outside_jql(
+@pytest.mark.parametrize(
+    ("scope", "expected_scope"),
+    [
+        ({"trace_ids": ["trace-1"]}, {"trace_ids": ["trace-1"]}),
+        ({"session_ids": ["session-1"]}, {"session_ids": ["session-1"]}),
+    ],
+)
+def test_judgeval_query_sends_scope_outside_jql(
     monkeypatch: pytest.MonkeyPatch,
+    scope: dict[str, list[str]],
+    expected_scope: dict[str, list[str]],
 ) -> None:
     monkeypatch.setattr("judgeval.judgeval.resolve_project_id", lambda *_: "project-1")
     calls = []
@@ -30,7 +39,7 @@ def test_judgeval_query_sends_session_scope_outside_jql(
         api_url="https://api.example.com/",
     )
 
-    response = client.query(spans().rows(), session_ids=["session-1"])
+    response = client.query(spans().rows(), **scope)  # type: ignore[arg-type]
 
     assert {"calls": calls, "response": response} == {
         "calls": [
@@ -43,7 +52,7 @@ def test_judgeval_query_sends_session_scope_outside_jql(
                         "source": "spans",
                         "select": {"op": "rows"},
                     },
-                    "session_ids": ["session-1"],
+                    **expected_scope,
                 },
                 None,
             )
@@ -54,4 +63,44 @@ def test_judgeval_query_sends_session_scope_outside_jql(
             "row_count": 1,
             "elapsed_ms": 4,
         },
+    }
+
+
+def test_judgeval_query_rejects_trace_and_session_scope_together(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("judgeval.judgeval.resolve_project_id", lambda *_: "project-1")
+    calls = []
+
+    def fake_request(self, method, url, payload, params=None):  # type: ignore[no-untyped-def]
+        calls.append((method, url, payload, params))
+        raise AssertionError("must not run")
+
+    monkeypatch.setattr(JudgmentSyncClient, "_request", fake_request)
+    client = Judgeval(
+        project_name="demo",
+        api_key="api-key",
+        organization_id="org-1",
+        api_url="https://api.example.com/",
+    )
+
+    with pytest.raises(ValueError) as caught:
+        client.query(
+            spans().rows(),
+            trace_ids=["trace-1"],
+            session_ids=["session-1"],
+        )
+
+    assert {
+        "error": {
+            "type": type(caught.value).__name__,
+            "message": str(caught.value),
+        },
+        "calls": calls,
+    } == {
+        "error": {
+            "type": "ValueError",
+            "message": "trace_ids and session_ids are mutually exclusive",
+        },
+        "calls": [],
     }

--- a/src/tests/jql/test_session_scope.py
+++ b/src/tests/jql/test_session_scope.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+
+from judgeval import Judgeval
+from judgeval.internal.api.api_client import JudgmentSyncClient
+from judgeval.jql import spans
+
+
+def test_judgeval_query_sends_session_scope_outside_jql(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("judgeval.judgeval.resolve_project_id", lambda *_: "project-1")
+    calls = []
+
+    def fake_request(self, method, url, payload, params=None):  # type: ignore[no-untyped-def]
+        calls.append((method, url, payload, params))
+        return {
+            "query_id": "q-1",
+            "rows": [{"span_id": "span-1"}],
+            "row_count": 1,
+            "elapsed_ms": 4,
+        }
+
+    monkeypatch.setattr(JudgmentSyncClient, "_request", fake_request)
+    client = Judgeval(
+        project_name="demo",
+        api_key="api-key",
+        organization_id="org-1",
+        api_url="https://api.example.com/",
+    )
+
+    response = client.query(spans().rows(), session_ids=["session-1"])
+
+    assert {"calls": calls, "response": response} == {
+        "calls": [
+            (
+                "POST",
+                "https://api.example.com/v1/projects/project-1/query",
+                {
+                    "query": {
+                        "op": "query",
+                        "source": "spans",
+                        "select": {"op": "rows"},
+                    },
+                    "session_ids": ["session-1"],
+                },
+                None,
+            )
+        ],
+        "response": {
+            "query_id": "q-1",
+            "rows": [{"span_id": "span-1"}],
+            "row_count": 1,
+            "elapsed_ms": 4,
+        },
+    }


### PR DESCRIPTION
## Summary

- add mutually exclusive `trace_ids` and `session_ids` options to `query`, `present`, and `discover`
- serialize both scopes outside canonical JQL JSON in the public request envelope
- reject combined trace + session scope locally before the HTTP request
- expose canonical `offline_traces()` and `offline_spans()` query roots
- generate Python query roots and their `QuerySource` registry from `SourceQuery.source`
- include generated roots in PR, staging-release, production-release, and manual-release parity checks
- refresh the public-safe JQL contract snapshot and document scoped and offline queries
- add exact full-value coverage for trace scope, session scope, and both offline roots

## Testing

- `uv run pytest tests -n auto -q` from `src` — 644 passed, 1 skipped
- focused JQL tests — 22 passed
- `uv run mypy ./src/judgeval/` — 197 source files clean
- `uv run ruff format --check .` — 296 files clean
- `uv run ruff check .`
- `uv build`
- `uv run python scripts/check_distribution_contents.py`
- canonical regeneration from JudgmentLabs/judgment-mono#3539 followed by an exact no-diff check across all generated JQL modules

## Rollout

Depends on JudgmentLabs/judgment-mono#3539 for trace/session request-envelope support. Merge and deploy the public JQL gateway before releasing this SDK change.