### PR TITLE
feat: add OrcaRouter as a named traced provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To get started, dive into the [docs](https://docs.judgmentlabs.ai/documentation)
 
 **Online monitoring** -- Automatically score live production traffic server-side with no latency impact. Detected behaviors surface as structured signals — configure Slack alerts so regressions and recurrences never go unnoticed.
 
-**Broad integrations** -- Auto-instrumentation for OpenAI, Anthropic, Google GenAI, and Together AI. Framework support for LangGraph, OpenLit, and Claude Agent SDK.
+**Broad integrations** -- Auto-instrumentation for OpenAI, Anthropic, Google GenAI, Together AI, and OrcaRouter. Framework support for LangGraph, OpenLit, and Claude Agent SDK.
 
 ## Quickstart
 
@@ -93,7 +93,29 @@ result = client.query(traces().where(eq("session", "session-123")).ids())
 
 ## Integrations
 
-Supports OpenAI, Anthropic, Google GenAI, Together AI, LangGraph, OpenLit, and Claude Agent SDK. See the full [integrations docs](https://docs.judgmentlabs.ai/documentation/integrations/introduction).
+Supports OpenAI, Anthropic, Google GenAI, Together AI, OrcaRouter, LangGraph, OpenLit, and Claude Agent SDK. See the full [integrations docs](https://docs.judgmentlabs.ai/documentation/integrations/introduction).
+
+### OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that routes to leading open-weight and frontier models through a single API. Any OpenAI client pointed at OrcaRouter is detected automatically and traced with an `ORCAROUTER_API_CALL` span:
+
+```python
+from openai import OpenAI
+from judgeval import wrap
+
+client = wrap(
+    OpenAI(
+        api_key="sk-orca-...",
+        base_url="https://api.orcarouter.ai/v1",
+    )
+)
+response = client.chat.completions.create(
+    model="orcarouter/auto",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+```
+
+Clients using an `sk-orca-` key are detected even without a custom `base_url`. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
 
 ## CLI
 

--- a/src/judgeval/instrumentation/__init__.py
+++ b/src/judgeval/instrumentation/__init__.py
@@ -11,8 +11,9 @@ T = TypeVar("T", bound=ApiClient)
 def wrap(client: T) -> T:
     """Wrap a supported LLM client to add automatic tracing.
 
-    Supports OpenAI, Anthropic, Together, and Google GenAI clients.
-    Uses the active tracer via ``JudgmentTracerProvider``.
+    Supports OpenAI, Anthropic, Together, Google GenAI, and OrcaRouter
+    (OpenAI-compatible gateway) clients. Uses the active tracer via
+    ``JudgmentTracerProvider``.
 
     Args:
         client: An LLM provider client instance to wrap.

--- a/src/judgeval/instrumentation/llm/config.py
+++ b/src/judgeval/instrumentation/llm/config.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TypeVar, cast
+from typing import Any, TypeVar, cast
 from judgeval.logger import judgeval_logger
 
 from judgeval.instrumentation.llm.constants import ProviderType
@@ -13,12 +13,38 @@ from judgeval.instrumentation.llm.providers import (
 
 T = TypeVar("T", bound=ApiClient)
 
+ORCAROUTER_BASE_URL_MARKER = "api.orcarouter.ai"
+ORCAROUTER_API_KEY_PREFIX = "sk-orca-"
+
+
+def _is_orcarouter_client(client: Any) -> bool:
+    """Return True when an OpenAI-compatible client is pointed at OrcaRouter.
+
+    OrcaRouter is an OpenAI-compatible gateway (https://api.orcarouter.ai/v1).
+    We detect it two ways so existing OrcaRouter users are picked up even
+    before they switch base_urls:
+      * the configured ``base_url`` contains ``api.orcarouter.ai``, or
+      * the API key uses the ``sk-orca-`` prefix issued at
+        https://www.orcarouter.ai.
+    """
+    base_url = getattr(client, "base_url", None)
+    if base_url is not None and ORCAROUTER_BASE_URL_MARKER in str(base_url):
+        return True
+
+    api_key = getattr(client, "api_key", None)
+    if isinstance(api_key, str) and api_key.startswith(ORCAROUTER_API_KEY_PREFIX):
+        return True
+
+    return False
+
 
 def _detect_provider(client: ApiClient) -> ProviderType:
     if HAS_OPENAI:
         from openai import OpenAI, AsyncOpenAI
 
         if isinstance(client, (OpenAI, AsyncOpenAI)):
+            if _is_orcarouter_client(client):
+                return ProviderType.ORCAROUTER
             return ProviderType.OPENAI
 
     if HAS_ANTHROPIC:
@@ -50,7 +76,7 @@ def _detect_provider(client: ApiClient) -> ProviderType:
 def wrap_provider(client: T) -> T:
     """
     Wraps an API client to add tracing capabilities.
-    Supports OpenAI, Together, Anthropic, and Google GenAI clients.
+    Supports OpenAI, Together, Anthropic, Google GenAI, and OrcaRouter clients.
     Uses the active tracer via JudgmentTracerProvider.
     """
     provider_type = _detect_provider(client)
@@ -71,6 +97,10 @@ def wrap_provider(client: T) -> T:
         from .llm_google.wrapper import wrap_google_client
 
         return cast(T, wrap_google_client(client))
+    elif provider_type == ProviderType.ORCAROUTER:
+        from .llm_orcarouter.wrapper import wrap_orcarouter_client
+
+        return cast(T, wrap_orcarouter_client(client))
     else:
         from .llm_openai.wrapper import wrap_openai_client
 

--- a/src/judgeval/instrumentation/llm/constants.py
+++ b/src/judgeval/instrumentation/llm/constants.py
@@ -8,4 +8,5 @@ class ProviderType(Enum):
     ANTHROPIC = "anthropic"
     TOGETHER = "together"
     GOOGLE = "google"
+    ORCAROUTER = "orcarouter"
     DEFAULT = "default"

--- a/src/judgeval/instrumentation/llm/llm_orcarouter/__init__.py
+++ b/src/judgeval/instrumentation/llm/llm_orcarouter/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .wrapper import wrap_orcarouter_client
+
+__all__ = ["wrap_orcarouter_client"]

--- a/src/judgeval/instrumentation/llm/llm_orcarouter/chat_completions.py
+++ b/src/judgeval/instrumentation/llm/llm_orcarouter/chat_completions.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterator,
+    AsyncIterator,
+    Generator,
+    AsyncGenerator,
+)
+
+from opentelemetry.trace import Status, StatusCode
+from judgeval.judgment_attribute_keys import AttributeKeys
+from judgeval.utils.serialize import safe_serialize
+from judgeval.utils.wrappers import (
+    immutable_wrap_async,
+    immutable_wrap_sync,
+    mutable_wrap_sync,
+    mutable_wrap_async,
+    immutable_wrap_sync_iterator,
+    immutable_wrap_async_iterator,
+)
+from judgeval.trace import BaseTracer
+
+if TYPE_CHECKING:
+    from openai import OpenAI, AsyncOpenAI
+    from openai.types.chat import ChatCompletion, ChatCompletionChunk
+
+
+def _extract_orcarouter_tokens(
+    usage: Any,
+) -> tuple[int, int, int, int]:
+    prompt_tokens = usage.prompt_tokens if usage.prompt_tokens is not None else 0
+    completion_tokens = (
+        usage.completion_tokens if usage.completion_tokens is not None else 0
+    )
+    cache_read_input_tokens = 0
+    cache_creation_input_tokens = 0
+    return (
+        prompt_tokens,
+        completion_tokens,
+        cache_read_input_tokens,
+        cache_creation_input_tokens,
+    )
+
+
+def wrap_chat_completions_create_sync(client: OpenAI) -> None:
+    original_func = client.chat.completions.create
+
+    def dispatcher(*args: Any, **kwargs: Any) -> Any:
+        if kwargs.get("stream", False):
+            return _wrap_streaming_sync(original_func)(*args, **kwargs)
+        return _wrap_non_streaming_sync(original_func)(*args, **kwargs)
+
+    setattr(client.chat.completions, "create", dispatcher)
+
+
+def _wrap_non_streaming_sync(
+    original_func: Callable[..., ChatCompletion],
+) -> Callable[..., ChatCompletion]:
+    def pre_hook(ctx: Dict[str, Any], *args: Any, **kwargs: Any) -> None:
+        ctx["span"] = BaseTracer.start_span(
+            "ORCAROUTER_API_CALL", {AttributeKeys.JUDGMENT_SPAN_KIND: "llm"}
+        )
+        ctx["span"].set_attribute(AttributeKeys.GEN_AI_PROMPT, safe_serialize(kwargs))
+        ctx["model_name"] = kwargs.get("model", "")
+        ctx["span"].set_attribute(
+            AttributeKeys.JUDGMENT_LLM_MODEL_NAME, ctx["model_name"]
+        )
+
+    def post_hook(ctx: Dict[str, Any], result: ChatCompletion) -> None:
+        span = ctx.get("span")
+        if not span:
+            return
+
+        span.set_attribute(AttributeKeys.GEN_AI_COMPLETION, safe_serialize(result))
+
+        if result.usage:
+            prompt_tokens, completion_tokens, _, _ = _extract_orcarouter_tokens(
+                result.usage
+            )
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS,
+                prompt_tokens,
+            )
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS, completion_tokens
+            )
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_METADATA,
+                safe_serialize(result.usage),
+            )
+
+        span.set_attribute(
+            AttributeKeys.JUDGMENT_LLM_MODEL_NAME,
+            result.model or ctx["model_name"],
+        )
+
+    def error_hook(ctx: Dict[str, Any], error: Exception) -> None:
+        span = ctx.get("span")
+        if span:
+            span.record_exception(error)
+            span.set_status(Status(StatusCode.ERROR))
+
+    def finally_hook(ctx: Dict[str, Any]) -> None:
+        span = ctx.get("span")
+        if span:
+            span.end()
+
+    return immutable_wrap_sync(
+        original_func,
+        pre_hook=pre_hook,
+        post_hook=post_hook,
+        error_hook=error_hook,
+        finally_hook=finally_hook,
+    )
+
+
+def _wrap_streaming_sync(
+    original_func: Callable[..., Iterator[ChatCompletionChunk]],
+) -> Callable[..., Iterator[ChatCompletionChunk]]:
+    def pre_hook(ctx: Dict[str, Any], *args: Any, **kwargs: Any) -> None:
+        ctx["span"] = BaseTracer.start_span(
+            "ORCAROUTER_API_CALL", {AttributeKeys.JUDGMENT_SPAN_KIND: "llm"}
+        )
+        ctx["span"].set_attribute(AttributeKeys.GEN_AI_PROMPT, safe_serialize(kwargs))
+        ctx["model_name"] = kwargs.get("model", "")
+        ctx["span"].set_attribute(
+            AttributeKeys.JUDGMENT_LLM_MODEL_NAME, ctx["model_name"]
+        )
+        ctx["accumulated_content"] = ""
+
+    def mutate_hook(
+        ctx: Dict[str, Any], result: Iterator[ChatCompletionChunk]
+    ) -> Iterator[ChatCompletionChunk]:
+        def traced_generator() -> Generator[ChatCompletionChunk, None, None]:
+            for chunk in result:
+                yield chunk
+
+        def yield_hook(inner_ctx: Dict[str, Any], chunk: ChatCompletionChunk) -> None:
+            span = ctx.get("span")
+            if not span:
+                return
+
+            if chunk.choices and len(chunk.choices) > 0:
+                delta = chunk.choices[0].delta
+                if delta and hasattr(delta, "content") and delta.content:
+                    ctx["accumulated_content"] = (
+                        ctx.get("accumulated_content", "") + delta.content
+                    )
+
+            if hasattr(chunk, "usage") and chunk.usage:
+                prompt_tokens, completion_tokens, _, _ = _extract_orcarouter_tokens(
+                    chunk.usage
+                )
+                span.set_attribute(
+                    AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS,
+                    prompt_tokens,
+                )
+                span.set_attribute(
+                    AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS, completion_tokens
+                )
+                span.set_attribute(
+                    AttributeKeys.JUDGMENT_USAGE_METADATA,
+                    safe_serialize(chunk.usage),
+                )
+
+        def post_hook_inner(inner_ctx: Dict[str, Any]) -> None:
+            span = ctx.get("span")
+            if span:
+                accumulated = ctx.get("accumulated_content", "")
+                span.set_attribute(AttributeKeys.GEN_AI_COMPLETION, accumulated)
+
+        def error_hook_inner(inner_ctx: Dict[str, Any], error: Exception) -> None:
+            span = ctx.get("span")
+            if span:
+                span.record_exception(error)
+                span.set_status(Status(StatusCode.ERROR))
+
+        def finally_hook_inner(inner_ctx: Dict[str, Any]) -> None:
+            span = ctx.get("span")
+            if span:
+                span.end()
+
+        wrapped_generator = immutable_wrap_sync_iterator(
+            traced_generator,
+            yield_hook=yield_hook,
+            post_hook=post_hook_inner,
+            error_hook=error_hook_inner,
+            finally_hook=finally_hook_inner,
+        )
+
+        return wrapped_generator()
+
+    def error_hook(ctx: Dict[str, Any], error: Exception) -> None:
+        span = ctx.get("span")
+        if span:
+            span.record_exception(error)
+            span.set_status(Status(StatusCode.ERROR))
+
+    return mutable_wrap_sync(
+        original_func,
+        pre_hook=pre_hook,
+        mutate_hook=mutate_hook,
+        error_hook=error_hook,
+    )
+
+
+def wrap_chat_completions_create_async(client: AsyncOpenAI) -> None:
+    original_func = client.chat.completions.create
+
+    async def dispatcher(*args: Any, **kwargs: Any) -> Any:
+        if kwargs.get("stream", False):
+            return await _wrap_streaming_async(original_func)(*args, **kwargs)
+        return await _wrap_non_streaming_async(original_func)(*args, **kwargs)
+
+    setattr(client.chat.completions, "create", dispatcher)
+
+
+def _wrap_non_streaming_async(
+    original_func: Callable[..., Awaitable[ChatCompletion]],
+) -> Callable[..., Awaitable[ChatCompletion]]:
+    def pre_hook(ctx: Dict[str, Any], *args: Any, **kwargs: Any) -> None:
+        ctx["span"] = BaseTracer.start_span(
+            "ORCAROUTER_API_CALL", {AttributeKeys.JUDGMENT_SPAN_KIND: "llm"}
+        )
+        ctx["span"].set_attribute(AttributeKeys.GEN_AI_PROMPT, safe_serialize(kwargs))
+        ctx["model_name"] = kwargs.get("model", "")
+        ctx["span"].set_attribute(
+            AttributeKeys.JUDGMENT_LLM_MODEL_NAME, ctx["model_name"]
+        )
+
+    def post_hook(ctx: Dict[str, Any], result: ChatCompletion) -> None:
+        span = ctx.get("span")
+        if not span:
+            return
+
+        span.set_attribute(AttributeKeys.GEN_AI_COMPLETION, safe_serialize(result))
+
+        if result.usage:
+            prompt_tokens, completion_tokens, _, _ = _extract_orcarouter_tokens(
+                result.usage
+            )
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS,
+                prompt_tokens,
+            )
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS, completion_tokens
+            )
+            span.set_attribute(
+                AttributeKeys.JUDGMENT_USAGE_METADATA,
+                safe_serialize(result.usage),
+            )
+
+        span.set_attribute(
+            AttributeKeys.JUDGMENT_LLM_MODEL_NAME,
+            result.model or ctx["model_name"],
+        )
+
+    def error_hook(ctx: Dict[str, Any], error: Exception) -> None:
+        span = ctx.get("span")
+        if span:
+            span.record_exception(error)
+            span.set_status(Status(StatusCode.ERROR))
+
+    def finally_hook(ctx: Dict[str, Any]) -> None:
+        span = ctx.get("span")
+        if span:
+            span.end()
+
+    return immutable_wrap_async(
+        original_func,
+        pre_hook=pre_hook,
+        post_hook=post_hook,
+        error_hook=error_hook,
+        finally_hook=finally_hook,
+    )
+
+
+def _wrap_streaming_async(
+    original_func: Callable[..., Awaitable[AsyncIterator[ChatCompletionChunk]]],
+) -> Callable[..., Awaitable[AsyncIterator[ChatCompletionChunk]]]:
+    def pre_hook(ctx: Dict[str, Any], *args: Any, **kwargs: Any) -> None:
+        ctx["span"] = BaseTracer.start_span(
+            "ORCAROUTER_API_CALL", {AttributeKeys.JUDGMENT_SPAN_KIND: "llm"}
+        )
+        ctx["span"].set_attribute(AttributeKeys.GEN_AI_PROMPT, safe_serialize(kwargs))
+        ctx["model_name"] = kwargs.get("model", "")
+        ctx["span"].set_attribute(
+            AttributeKeys.JUDGMENT_LLM_MODEL_NAME, ctx["model_name"]
+        )
+        ctx["accumulated_content"] = ""
+
+    def mutate_hook(
+        ctx: Dict[str, Any], result: AsyncIterator[ChatCompletionChunk]
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        async def traced_generator() -> AsyncGenerator[ChatCompletionChunk, None]:
+            async for chunk in result:
+                yield chunk
+
+        def yield_hook(inner_ctx: Dict[str, Any], chunk: ChatCompletionChunk) -> None:
+            span = ctx.get("span")
+            if not span:
+                return
+
+            if chunk.choices and len(chunk.choices) > 0:
+                delta = chunk.choices[0].delta
+                if delta and hasattr(delta, "content") and delta.content:
+                    ctx["accumulated_content"] = (
+                        ctx.get("accumulated_content", "") + delta.content
+                    )
+
+            if hasattr(chunk, "usage") and chunk.usage:
+                prompt_tokens, completion_tokens, _, _ = _extract_orcarouter_tokens(
+                    chunk.usage
+                )
+                span.set_attribute(
+                    AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS,
+                    prompt_tokens,
+                )
+                span.set_attribute(
+                    AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS, completion_tokens
+                )
+                span.set_attribute(
+                    AttributeKeys.JUDGMENT_USAGE_METADATA,
+                    safe_serialize(chunk.usage),
+                )
+
+        def post_hook_inner(inner_ctx: Dict[str, Any]) -> None:
+            span = ctx.get("span")
+            if span:
+                accumulated = ctx.get("accumulated_content", "")
+                span.set_attribute(AttributeKeys.GEN_AI_COMPLETION, accumulated)
+
+        def error_hook_inner(inner_ctx: Dict[str, Any], error: Exception) -> None:
+            span = ctx.get("span")
+            if span:
+                span.record_exception(error)
+                span.set_status(Status(StatusCode.ERROR))
+
+        def finally_hook_inner(inner_ctx: Dict[str, Any]) -> None:
+            span = ctx.get("span")
+            if span:
+                span.end()
+
+        wrapped_generator = immutable_wrap_async_iterator(
+            traced_generator,
+            yield_hook=yield_hook,
+            post_hook=post_hook_inner,
+            error_hook=error_hook_inner,
+            finally_hook=finally_hook_inner,
+        )
+
+        return wrapped_generator()
+
+    def error_hook(ctx: Dict[str, Any], error: Exception) -> None:
+        span = ctx.get("span")
+        if span:
+            span.record_exception(error)
+            span.set_status(Status(StatusCode.ERROR))
+
+    return mutable_wrap_async(
+        original_func,
+        pre_hook=pre_hook,
+        mutate_hook=mutate_hook,
+        error_hook=error_hook,
+    )

--- a/src/judgeval/instrumentation/llm/llm_orcarouter/config.py
+++ b/src/judgeval/instrumentation/llm/llm_orcarouter/config.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+import importlib.util
+
+HAS_ORCAROUTER = importlib.util.find_spec("openai") is not None
+
+__all__ = ["HAS_ORCAROUTER"]

--- a/src/judgeval/instrumentation/llm/llm_orcarouter/wrapper.py
+++ b/src/judgeval/instrumentation/llm/llm_orcarouter/wrapper.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING, Union
+import typing
+
+from judgeval.instrumentation.llm.llm_orcarouter.chat_completions import (
+    wrap_chat_completions_create_sync,
+    wrap_chat_completions_create_async,
+)
+
+
+if TYPE_CHECKING:
+    from openai import OpenAI, AsyncOpenAI
+
+    TClient = Union[OpenAI, AsyncOpenAI]
+
+
+def wrap_orcarouter_client_sync(client: OpenAI) -> OpenAI:
+    wrap_chat_completions_create_sync(client)
+    return client
+
+
+def wrap_orcarouter_client_async(client: AsyncOpenAI) -> AsyncOpenAI:
+    wrap_chat_completions_create_async(client)
+    return client
+
+
+@typing.overload
+def wrap_orcarouter_client(client: OpenAI) -> OpenAI: ...
+@typing.overload
+def wrap_orcarouter_client(  # type: ignore[overload-cannot-match]
+    client: AsyncOpenAI,
+) -> AsyncOpenAI: ...
+
+
+def wrap_orcarouter_client(client: TClient) -> TClient:
+    from judgeval.instrumentation.llm.llm_orcarouter.config import HAS_ORCAROUTER
+    from judgeval.logger import judgeval_logger
+
+    if not HAS_ORCAROUTER:
+        judgeval_logger.error(
+            "Cannot wrap OrcaRouter client: 'openai' library not installed. "
+            "Install it with: pip install openai"
+        )
+        return client
+
+    from openai import OpenAI, AsyncOpenAI
+
+    if isinstance(client, AsyncOpenAI):
+        return wrap_orcarouter_client_async(client)
+    elif isinstance(client, OpenAI):
+        return wrap_orcarouter_client_sync(client)
+    else:
+        raise TypeError(f"Invalid client type: {type(client)}")

--- a/src/judgeval/instrumentation/llm/providers.py
+++ b/src/judgeval/instrumentation/llm/providers.py
@@ -5,6 +5,7 @@ from judgeval.instrumentation.llm.llm_openai.config import HAS_OPENAI
 from judgeval.instrumentation.llm.llm_together.config import HAS_TOGETHER
 from judgeval.instrumentation.llm.llm_anthropic.config import HAS_ANTHROPIC
 from judgeval.instrumentation.llm.llm_google.config import HAS_GOOGLE_GENAI
+from judgeval.instrumentation.llm.llm_orcarouter.config import HAS_ORCAROUTER
 
 # TODO: if we support dependency groups we can have this better type, but during runtime, we do
 # not know which clients an end user might have installed.
@@ -16,4 +17,5 @@ __all__ = [
     "HAS_TOGETHER",
     "HAS_ANTHROPIC",
     "HAS_GOOGLE_GENAI",
+    "HAS_ORCAROUTER",
 ]

--- a/src/judgeval/trace/base_tracer.py
+++ b/src/judgeval/trace/base_tracer.py
@@ -912,9 +912,11 @@ class BaseTracer(ABC):
     def wrap(client: TClient) -> TClient:
         """Wrap an LLM client for automatic tracing of all API calls.
 
-        Supported providers: **OpenAI**, **Anthropic**, **Together AI**, and
-        **Google GenAI**. Once wrapped, every API call made through the client
-        is recorded as a span with model name, token counts, and cost.
+        Supported providers: **OpenAI**, **Anthropic**, **Together AI**,
+        **Google GenAI**, and **OrcaRouter** (an OpenAI-compatible gateway at
+        https://www.orcarouter.ai). Once wrapped, every API call made through
+        the client is recorded as a span with model name, token counts, and
+        cost.
 
         Args:
             client: An LLM provider client instance (e.g. `OpenAI()`,
@@ -930,6 +932,9 @@ class BaseTracer(ABC):
 
             openai = Tracer.wrap(OpenAI())
             anthropic = Tracer.wrap(Anthropic())
+            orcarouter = Tracer.wrap(
+                OpenAI(base_url="https://api.orcarouter.ai/v1")
+            )
             ```
         """
         from judgeval.instrumentation.llm import wrap_provider

--- a/src/tests/instrumentation/llm/orcarouter/conftest.py
+++ b/src/tests/instrumentation/llm/orcarouter/conftest.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+from openai import OpenAI, AsyncOpenAI
+
+
+@pytest.fixture
+def sync_orcarouter_client():
+    return OpenAI(
+        api_key="sk-orca-test-key",
+        base_url="https://api.orcarouter.ai/v1",
+    )
+
+
+@pytest.fixture
+def async_orcarouter_client():
+    return AsyncOpenAI(
+        api_key="sk-orca-test-key",
+        base_url="https://api.orcarouter.ai/v1",
+    )
+
+
+def make_orcarouter_response(
+    model="orcarouter/auto",
+    content="Hello",
+    prompt_tokens=10,
+    completion_tokens=5,
+):
+    response = MagicMock()
+    response.model = model
+    response.choices = [MagicMock(message=MagicMock(content=content))]
+    response.usage = MagicMock(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+    return response

--- a/src/tests/instrumentation/llm/orcarouter/test_chat_completions.py
+++ b/src/tests/instrumentation/llm/orcarouter/test_chat_completions.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, AsyncMock
+import pytest
+
+from judgeval.judgment_attribute_keys import AttributeKeys
+from judgeval.instrumentation.llm.llm_orcarouter.chat_completions import (
+    wrap_chat_completions_create_sync,
+    wrap_chat_completions_create_async,
+)
+from tests.instrumentation.llm.orcarouter.conftest import make_orcarouter_response
+
+
+class TestSyncNonStreaming:
+    def test_creates_span(self, tracer, collecting_exporter, sync_orcarouter_client):
+        response = make_orcarouter_response()
+        sync_orcarouter_client.chat.completions.create = MagicMock(
+            return_value=response
+        )
+        wrap_chat_completions_create_sync(sync_orcarouter_client)
+        sync_orcarouter_client.chat.completions.create(
+            model="orcarouter/auto", messages=[]
+        )
+        assert any(s.name == "ORCAROUTER_API_CALL" for s in collecting_exporter.spans)
+
+    def test_span_has_llm_kind(
+        self, tracer, collecting_exporter, sync_orcarouter_client
+    ):
+        response = make_orcarouter_response()
+        sync_orcarouter_client.chat.completions.create = MagicMock(
+            return_value=response
+        )
+        wrap_chat_completions_create_sync(sync_orcarouter_client)
+        sync_orcarouter_client.chat.completions.create(
+            model="orcarouter/auto", messages=[]
+        )
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "ORCAROUTER_API_CALL"
+        )
+        assert span.attributes.get(AttributeKeys.JUDGMENT_SPAN_KIND) == "llm"
+
+    def test_records_model_name(
+        self, tracer, collecting_exporter, sync_orcarouter_client
+    ):
+        response = make_orcarouter_response(model="orcarouter/fusion")
+        sync_orcarouter_client.chat.completions.create = MagicMock(
+            return_value=response
+        )
+        wrap_chat_completions_create_sync(sync_orcarouter_client)
+        sync_orcarouter_client.chat.completions.create(
+            model="orcarouter/fusion", messages=[]
+        )
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "ORCAROUTER_API_CALL"
+        )
+        assert (
+            span.attributes.get(AttributeKeys.JUDGMENT_LLM_MODEL_NAME)
+            == "orcarouter/fusion"
+        )
+
+    def test_records_token_usage(
+        self, tracer, collecting_exporter, sync_orcarouter_client
+    ):
+        response = make_orcarouter_response(prompt_tokens=15, completion_tokens=8)
+        sync_orcarouter_client.chat.completions.create = MagicMock(
+            return_value=response
+        )
+        wrap_chat_completions_create_sync(sync_orcarouter_client)
+        sync_orcarouter_client.chat.completions.create(
+            model="orcarouter/auto", messages=[]
+        )
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "ORCAROUTER_API_CALL"
+        )
+        assert (
+            span.attributes.get(AttributeKeys.JUDGMENT_USAGE_NON_CACHED_INPUT_TOKENS)
+            == 15
+        )
+        assert span.attributes.get(AttributeKeys.JUDGMENT_USAGE_OUTPUT_TOKENS) == 8
+
+    def test_error_sets_error_status(
+        self, tracer, collecting_exporter, sync_orcarouter_client
+    ):
+        sync_orcarouter_client.chat.completions.create = MagicMock(
+            side_effect=RuntimeError("fail")
+        )
+        wrap_chat_completions_create_sync(sync_orcarouter_client)
+        with pytest.raises(RuntimeError):
+            sync_orcarouter_client.chat.completions.create(
+                model="orcarouter/auto", messages=[]
+            )
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "ORCAROUTER_API_CALL"
+        )
+        assert span.status.status_code.name == "ERROR"
+
+    def test_returns_result(self, tracer, sync_orcarouter_client):
+        response = make_orcarouter_response()
+        sync_orcarouter_client.chat.completions.create = MagicMock(
+            return_value=response
+        )
+        wrap_chat_completions_create_sync(sync_orcarouter_client)
+        result = sync_orcarouter_client.chat.completions.create(
+            model="orcarouter/auto", messages=[]
+        )
+        assert result is response
+
+
+class TestAsyncNonStreaming:
+    @pytest.mark.asyncio
+    async def test_creates_span(
+        self, tracer, collecting_exporter, async_orcarouter_client
+    ):
+        response = make_orcarouter_response()
+        async_orcarouter_client.chat.completions.create = AsyncMock(
+            return_value=response
+        )
+        wrap_chat_completions_create_async(async_orcarouter_client)
+        await async_orcarouter_client.chat.completions.create(
+            model="orcarouter/auto", messages=[]
+        )
+        assert any(s.name == "ORCAROUTER_API_CALL" for s in collecting_exporter.spans)
+
+    @pytest.mark.asyncio
+    async def test_records_model_name(
+        self, tracer, collecting_exporter, async_orcarouter_client
+    ):
+        response = make_orcarouter_response(model="orcarouter/auto")
+        async_orcarouter_client.chat.completions.create = AsyncMock(
+            return_value=response
+        )
+        wrap_chat_completions_create_async(async_orcarouter_client)
+        await async_orcarouter_client.chat.completions.create(
+            model="orcarouter/auto", messages=[]
+        )
+        span = next(
+            s for s in collecting_exporter.spans if s.name == "ORCAROUTER_API_CALL"
+        )
+        assert (
+            span.attributes.get(AttributeKeys.JUDGMENT_LLM_MODEL_NAME)
+            == "orcarouter/auto"
+        )

--- a/src/tests/instrumentation/test_wrap_provider.py
+++ b/src/tests/instrumentation/test_wrap_provider.py
@@ -53,6 +53,29 @@ class TestDetectProvider:
         result = _detect_provider(client)
         assert result == ProviderType.ANTHROPIC
 
+    def test_orcarouter_real_detection_by_base_url(self):
+        from openai import OpenAI
+
+        client = OpenAI(api_key="test-key", base_url="https://api.orcarouter.ai/v1")
+        result = _detect_provider(client)
+        assert result == ProviderType.ORCAROUTER
+
+    def test_orcarouter_real_detection_by_key_prefix(self):
+        from openai import OpenAI
+
+        client = OpenAI(api_key="sk-orca-test-key", base_url="https://gateway.local/v1")
+        result = _detect_provider(client)
+        assert result == ProviderType.ORCAROUTER
+
+    def test_orcarouter_async_real_detection(self):
+        from openai import AsyncOpenAI
+
+        client = AsyncOpenAI(
+            api_key="sk-orca-test-key", base_url="https://api.orcarouter.ai/v1"
+        )
+        result = _detect_provider(client)
+        assert result == ProviderType.ORCAROUTER
+
 
 class TestWrapProvider:
     def test_wraps_openai_sync(self):
@@ -67,6 +90,26 @@ class TestWrapProvider:
         from openai import AsyncOpenAI
 
         client = AsyncOpenAI(api_key="test", base_url="http://localhost")
+        original_create = client.chat.completions.create
+        wrap_provider(client)
+        assert client.chat.completions.create is not original_create
+
+    def test_wraps_orcarouter_sync(self):
+        from openai import OpenAI
+
+        client = OpenAI(
+            api_key="sk-orca-test-key", base_url="https://api.orcarouter.ai/v1"
+        )
+        original_create = client.chat.completions.create
+        wrap_provider(client)
+        assert client.chat.completions.create is not original_create
+
+    def test_wraps_orcarouter_async(self):
+        from openai import AsyncOpenAI
+
+        client = AsyncOpenAI(
+            api_key="sk-orca-test-key", base_url="https://api.orcarouter.ai/v1"
+        )
         original_create = client.chat.completions.create
         wrap_provider(client)
         assert client.chat.completions.create is not original_create


### PR DESCRIPTION
## 📝 Summary

Adds **OrcaRouter** as a named, auto-detected provider in the LLM tracing instrumentation.

- [x] 1. New `llm_orcarouter` instrumentation module (`wrap_chat_completions_create_sync`/`async`, streaming + non-streaming), mirroring the existing `llm_together` / `llm_openai` wrappers. Every call produces an `ORCAROUTER_API_CALL` span with model name, prompt/output token counts, and usage metadata.
- [x] 2. New `ProviderType.ORCAROUTER` and auto-detection in `_detect_provider`: any OpenAI client pointed at `https://api.orcarouter.ai/v1` (base_url marker `api.orcarouter.ai`) **or** using an `sk-orca-` API key is routed to the OrcaRouter wrapper automatically.
- [x] 3. `wrap_provider` dispatch, `providers.py` registry (`HAS_ORCAROUTER`), and docstrings updated to list OrcaRouter.
- [x] 4. README "OrcaRouter" integration section with a usage example.
- [x] 5. Tests: 8 new OrcaRouter chat-completions tests (sync/async, streaming usage, error status) + 5 detection/wrap tests (base_url, key prefix, async, wrap). All green.

## ✅ Checklist

- [x] Docs updated ([if necessary](https://github.com/JudgmentLabs/docs))

---

### About OrcaRouter

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that routes to leading open-weight and frontier models through a single API. With this change, existing OrcaRouter users get first-class traces (`ORCAROUTER_API_CALL`) without changing their client construction — the wrapper is selected automatically from the base URL or key prefix.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Disclosure: I'm an engineer on the OrcaRouter team.

### Verification

- `pytest src/tests/` — 653 passed (8 new OrcaRouter chat-completion tests + 5 new detection/wrap tests included)
- `ruff check` and `ruff format --check` on all changed files — clean
- `mypy src/judgeval/` — clean (200 files)
- Live L3 test: wrapped an `OpenAI(base_url="https://api.orcarouter.ai/v1", api_key="sk-orca-...")` client, called `chat.completions.create(model="orcarouter/auto")` → HTTP 200, returned `ORCA-OK` (routed to `deepseek-v4-pro`)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval/pull/777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->