### PR TITLE
fix(code_quality): Missing docstring on public function `initialize` in hatch_b

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -11,6 +11,16 @@ class CustomBuildHook(BuildHookInterface):
     """Regenerate deterministic JQL artifacts before building a distribution."""
 
     def initialize(self, version: str, build_data: dict[str, object]) -> None:
+        """Regenerate JQL artifacts when building from a repository checkout.
+
+        Skips generation when building from an sdist, which has neither a .git
+        directory nor the private build-time inputs required by generate_jql.py.
+
+        Args:
+            version: The version string supplied by Hatch for the current build.
+            build_data: Mutable mapping that Hatch uses to collect extra build
+                metadata (e.g. additional artifacts and forced inclusion paths).
+        """
         # Generated files are checked in. Regenerate only in a repository checkout;
         # an sdist installation has neither .git nor the private build-time inputs.
         if not (Path(self.root) / ".git").exists():


### PR DESCRIPTION
## TLDR

**Gap:** Missing docstring on public function `initialize` in hatch_build.py (JudgmentLabs/judgeval)

**Wedge type:** `code_quality`

**Issue:** https://github.com/JudgmentLabs/judgeval/blob/main/hatch_build.py

## Changes

- `hatch_build.py`

**Diff size:** 10 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval/pull/779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->