### PR TITLE
feat(offline_tests): add concurrency for offline agent test execution (JUD-9600)

### DIFF
--- a/src/judgeval/offline_tests/offline_test_runner.py
+++ b/src/judgeval/offline_tests/offline_test_runner.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
+import functools
 import inspect
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict, cast
 
 import orjson
@@ -413,16 +416,22 @@ class OfflineTestRunner:
         examples: List[Dict[str, Any]],
         progress: Optional[Progress] = None,
         field_mapping: Optional[Dict[str, str]] = None,
+        concurrency: int = 1,
     ) -> Dict[str, str]:
         """Call the agent entrypoint once per dataset example.
 
         Each call is wrapped in the `OfflineTracer` machinery so it
         produces a dedicated offline trace; the resulting trace IDs are
         returned keyed by example ID. Entrypoint/example field mismatches
-        raise immediately; runtime errors inside the agent are recorded on
-        the trace and logged, and the loop continues. The previously
-        active tracer (if any) is restored once the loop finishes, so
-        subsequent `@observe` spans do not route to the offline endpoint.
+        raise before any agent call. With `concurrency` > 1 that many
+        examples run at a time on worker threads (each call in a copy of
+        the current context, so the offline tracer stays active and
+        traces stay isolated per call); at 1 the agent runs sequentially
+        on the calling thread as before. Runtime errors inside the agent
+        are recorded on the trace and logged, and the remaining examples
+        still run. The previously active tracer (if any) is restored once
+        the loop finishes, so subsequent `@observe` spans do not route to
+        the offline endpoint.
 
         Before returning, the offline tracer is force-flushed and its
         provider shut down, so every agent trace is exported by the time
@@ -431,21 +440,38 @@ class OfflineTestRunner:
         from judgeval.trace.judgment_tracer_provider import JudgmentTracerProvider
         from judgeval.trace.offline_tracer import OfflineTracer
 
+        if concurrency < 1:
+            raise ValueError(f"concurrency must be >= 1, got {concurrency}")
+
+        # Fail fast on entrypoint/example mismatches before any agent call
+        # (and before any traces are exported).
+        kwargs_per_example = [
+            build_agent_kwargs(agent_function, example.get("data") or {}, field_mapping)
+            for example in examples
+        ]
+
         proxy = JudgmentTracerProvider.get_instance()
         previous_tracer = proxy.get_active_tracer()
 
-        captured: List[Example] = []
+        # The dataset list is required by OfflineTracer.create but unused
+        # here: example→trace correlation happens inside each observed call.
         tracer = OfflineTracer.create(
             project_name=self._project_name,
             api_key=self._client.api_key,
             organization_id=self._client.organization_id,
             api_url=self._client.base_url,
             set_active=True,
-            dataset=captured,
+            dataset=[],
         )
         try:
-            wrapped = tracer.observe(agent_function, span_type="agent")
             is_async = inspect.iscoroutinefunction(agent_function)
+            # An observed generator entrypoint is returned uniterated, so its
+            # span never ends and no trace is exported — record nothing for
+            # it rather than attach a trace id that won't exist server-side.
+            records_traces = not (
+                inspect.isgeneratorfunction(agent_function)
+                or inspect.isasyncgenfunction(agent_function)
+            )
 
             task = None
             if progress is not None:
@@ -453,13 +479,40 @@ class OfflineTestRunner:
                     f"Running agent over {len(examples)} example(s)...", total=None
                 )
 
-            agent_traces: Dict[str, str] = {}
-            for index, example in enumerate(examples):
+            def invoke(
+                example: Dict[str, Any], kwargs: Dict[str, Any]
+            ) -> Tuple[str, Optional[str]]:
                 example_id = example.get("example_id") or ""
-                data = example.get("data") or {}
-                kwargs = build_agent_kwargs(agent_function, data, field_mapping)
 
-                before = len(captured)
+                # Capture the offline trace id from inside the observed
+                # call: correlation by example, safe under concurrency.
+                holder: Dict[str, str] = {}
+
+                def record_trace_id() -> None:
+                    # If activation was refused (run() nested inside a live
+                    # root span) spans route to the live tracer; don't attach
+                    # a foreign trace id.
+                    if not records_traces or proxy.get_active_tracer() is not tracer:
+                        return
+                    ids = tracer._get_current_trace_and_span_id()
+                    if ids:
+                        holder["trace_id"] = ids[0]
+
+                probe: AgentFunction
+                if is_async:
+
+                    @functools.wraps(agent_function)
+                    async def probe(**kw: Any) -> Any:
+                        record_trace_id()
+                        return await agent_function(**kw)
+                else:
+
+                    @functools.wraps(agent_function)
+                    def probe(**kw: Any) -> Any:
+                        record_trace_id()
+                        return agent_function(**kw)
+
+                wrapped = tracer.observe(probe, span_type="agent")
                 try:
                     if is_async:
                         asyncio.run(wrapped(**kwargs))
@@ -469,18 +522,40 @@ class OfflineTestRunner:
                     judgeval_logger.error(
                         f"Agent entrypoint raised for example {example_id}: {exc}"
                     )
+                return example_id, holder.get("trace_id")
 
-                for produced in captured[before:]:
-                    offline_trace_id = produced._properties.get("offline_trace_id")
-                    if example_id and offline_trace_id:
-                        agent_traces[example_id] = offline_trace_id
-                        break
+            agent_traces: Dict[str, str] = {}
 
+            def collect(result: Tuple[str, Optional[str]], completed: int) -> None:
+                example_id, trace_id = result
+                if example_id and trace_id:
+                    agent_traces[example_id] = trace_id
                 if progress is not None and task is not None:
                     progress.update(
                         task,
-                        description=f"Running agent... ({index + 1}/{len(examples)})",
+                        description=f"Running agent... ({completed}/{len(examples)})",
                     )
+
+            if concurrency == 1:
+                # Stay on the calling thread so thread-affine agents
+                # (signals, sqlite handles, ...) keep working by default.
+                for index, example in enumerate(examples):
+                    collect(invoke(example, kwargs_per_example[index]), index + 1)
+            else:
+                # copy_context() carries the active-tracer ContextVar into
+                # the worker threads; without it no spans would be recorded.
+                pool = ThreadPoolExecutor(max_workers=concurrency)
+                try:
+                    futures = [
+                        pool.submit(contextvars.copy_context().run, invoke, ex, kw)
+                        for ex, kw in zip(examples, kwargs_per_example)
+                    ]
+                    for completed, future in enumerate(as_completed(futures), 1):
+                        collect(future.result(), completed)
+                finally:
+                    # Drop still-queued examples on interrupt/error instead
+                    # of draining the whole dataset before surfacing it.
+                    pool.shutdown(wait=True, cancel_futures=True)
         finally:
             tracer.force_flush()
             proxy.restore_active(previous_tracer)
@@ -757,19 +832,23 @@ class OfflineTestRunner:
         timeout_seconds: int = 600,
         run_name: Optional[str] = None,
         field_mapping: Optional[Dict[str, str]] = None,
+        concurrency: int = 1,
     ) -> OfflineTestResult:
         """Execute the full offline-test lifecycle for a test config.
 
         When ``agent_function`` is omitted, no agent is invoked: the judges
         score each example's existing trace (the dataset's trace-typed
         column / ``offline_trace_id``). When provided, the agent is run once
-        per example first and the judges score the resulting agent trace.
+        per example first (up to ``concurrency`` examples at a time) and the
+        judges score the resulting agent trace.
         """
         if assert_test and pass_condition_fn is None:
             raise ValueError(
                 "assert_test=True requires a pass_condition_fn to decide "
                 "whether each row passes."
             )
+        if concurrency < 1:
+            raise ValueError(f"concurrency must be >= 1, got {concurrency}")
 
         console = Console()
         console.print("\n[bold cyan]Starting Offline Test[/bold cyan]")
@@ -803,7 +882,7 @@ class OfflineTestRunner:
             agent_traces: Dict[str, str] = {}
             if agent_function is not None and examples:
                 agent_traces = self.run_agent(
-                    agent_function, examples, progress, field_mapping
+                    agent_function, examples, progress, field_mapping, concurrency
                 )
 
             prepared = self.create_test_run(

--- a/src/judgeval/offline_tests/offline_tests_factory.py
+++ b/src/judgeval/offline_tests/offline_tests_factory.py
@@ -227,6 +227,7 @@ class OfflineTestsFactory:
         timeout_seconds: int = 600,
         run_name: Optional[str] = None,
         field_mapping: Optional[Dict[str, str]] = None,
+        concurrency: int = 1,
     ) -> Optional[OfflineTestResult]:
         """Run an offline test for a test config.
 
@@ -279,6 +280,14 @@ class OfflineTestsFactory:
                 field ``question``). Unmapped parameters fall back to the field
                 of the same name. Example fields the agent does not declare are
                 ignored.
+            concurrency: Maximum number of examples the agent runs over at
+                a time. Defaults to 1 (sequential, on the calling thread).
+                Above 1, calls run on worker threads; an async agent runs
+                each example under its own event loop, so create per-call
+                async clients inside the agent rather than sharing a
+                module-level one across calls. Only affects the agent
+                execution loop; judge scoring happens server-side and is
+                unaffected.
 
         Returns:
             An `OfflineTestResult`, or `None` if the project is not
@@ -286,8 +295,8 @@ class OfflineTestsFactory:
 
         Raises:
             ValueError: If `assert_test` is set without `pass_condition_fn`,
-                or if `dataset_version` does not match any version of the
-                config's dataset.
+                if `dataset_version` does not match any version of the
+                config's dataset, or if `concurrency` is less than 1.
             TypeError: If the agent entrypoint cannot accept an example's
                 fields.
             JudgmentValidationError: If the server rejects the run (e.g.
@@ -321,4 +330,5 @@ class OfflineTestsFactory:
             timeout_seconds=timeout_seconds,
             run_name=run_name,
             field_mapping=field_mapping,
+            concurrency=concurrency,
         )

--- a/src/tests/offline_tests/test_offline_test_runner.py
+++ b/src/tests/offline_tests/test_offline_test_runner.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import contextlib
+import contextvars
+import functools
+import inspect
+import itertools
 import json
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -816,7 +822,9 @@ class TestRunOrchestration:
             calls.append(input)
             return f"answer to {input}"
 
-        def fake_run_agent(agent_function, examples, progress=None, field_mapping=None):
+        def fake_run_agent(
+            agent_function, examples, progress=None, field_mapping=None, concurrency=1
+        ):
             # examples come from the dataset fetch, not the prepare response
             assert [e["example_id"] for e in examples] == ["ex-1"]
             for example in examples:
@@ -837,7 +845,9 @@ class TestRunOrchestration:
         runner, client = _make_runner()
         _stub_lifecycle(client)
 
-        def fake_run_agent(agent_function, examples, progress=None, field_mapping=None):
+        def fake_run_agent(
+            agent_function, examples, progress=None, field_mapping=None, concurrency=1
+        ):
             return {"ex-1": "trace-abc"}
 
         with patch.object(OfflineTestRunner, "run_agent", side_effect=fake_run_agent):
@@ -861,7 +871,9 @@ class TestRunOrchestration:
         _stub_lifecycle(client)
         order = []
 
-        def fake_run_agent(agent_function, examples, progress=None, field_mapping=None):
+        def fake_run_agent(
+            agent_function, examples, progress=None, field_mapping=None, concurrency=1
+        ):
             order.append("agent")
             assert client.post_projects_test_runs.call_count == 0
             return {"ex-1": "trace-abc"}
@@ -912,20 +924,8 @@ class TestRunOrchestration:
         client.base_url = "http://localhost"
 
         tracer = MagicMock()
-
-        def fake_create(**kwargs):
-            dataset = kwargs["dataset"]
-
-            def observe(func, span_type=None):
-                def wrapper(**call_kwargs):
-                    result = func(**call_kwargs)
-                    dataset.append(Example.create(offline_trace_id="trace-abc"))
-                    return result
-
-                return wrapper
-
-            tracer.observe = observe
-            return tracer
+        tracer.observe = lambda func, span_type=None: func
+        tracer._get_current_trace_and_span_id = lambda: ("trace-abc", "span-0")
 
         def fake_post(**kwargs):
             # by the time the run is created, the offline tracer has been
@@ -936,10 +936,7 @@ class TestRunOrchestration:
 
         client.post_projects_test_runs.side_effect = fake_post
 
-        with patch(
-            "judgeval.trace.offline_tracer.OfflineTracer.create",
-            side_effect=fake_create,
-        ):
+        with _patched_offline_tracer(tracer):
             outcome = runner.run(CONFIG, agent_function=lambda input: input)
 
         assert outcome.agent_offline_trace_ids == {"ex-1": "trace-abc"}
@@ -952,6 +949,72 @@ class TestRunOrchestration:
             runner.run(CONFIG, timeout_seconds=0)
 
 
+def _stub_tracer():
+    """Fake `OfflineTracer` that assigns one trace id per observed call via
+    a ContextVar, mirroring how the real tracer scopes a root span per call
+    (isolated per thread/task, readable from inside the call)."""
+    tracer = MagicMock()
+    counter = itertools.count()
+    lock = threading.Lock()
+    current: contextvars.ContextVar = contextvars.ContextVar(
+        "stub_trace_id", default=None
+    )
+    tracer._current_var = current
+
+    def _next_id():
+        with lock:
+            return f"trace-{next(counter)}"
+
+    def observe(func, span_type=None):
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(**call_kwargs):
+                token = current.set(_next_id())
+                try:
+                    return await func(**call_kwargs)
+                finally:
+                    current.reset(token)
+
+            return async_wrapper
+
+        @functools.wraps(func)
+        def wrapper(**call_kwargs):
+            token = current.set(_next_id())
+            try:
+                return func(**call_kwargs)
+            finally:
+                current.reset(token)
+
+        return wrapper
+
+    tracer.observe = observe
+    tracer._get_current_trace_and_span_id = lambda: (
+        (current.get(), "span-0") if current.get() else None
+    )
+    return tracer
+
+
+@contextlib.contextmanager
+def _patched_offline_tracer(tracer):
+    """Patch OfflineTracer.create to return `tracer` and make the proxy
+    provider report it as the active tracer (run_agent only records trace
+    ids while its own offline tracer is active)."""
+    proxy = MagicMock()
+    proxy.get_active_tracer.return_value = tracer
+    with (
+        patch(
+            "judgeval.trace.offline_tracer.OfflineTracer.create",
+            return_value=tracer,
+        ),
+        patch(
+            "judgeval.trace.judgment_tracer_provider.JudgmentTracerProvider.get_instance",
+            return_value=proxy,
+        ),
+    ):
+        yield
+
+
 class TestRunAgentLoop:
     def test_run_agent_wraps_with_offline_tracer(self):
         runner, client = _make_runner()
@@ -959,25 +1022,7 @@ class TestRunAgentLoop:
         client.organization_id = "org"
         client.base_url = "http://localhost"
 
-        tracer = MagicMock()
-        captured_examples = []
-
-        def fake_create(**kwargs):
-            captured_examples.append(kwargs["dataset"])
-            dataset = kwargs["dataset"]
-
-            def observe(func, span_type=None):
-                def wrapper(**call_kwargs):
-                    result = func(**call_kwargs)
-                    dataset.append(
-                        Example.create(offline_trace_id=f"trace-{len(dataset)}")
-                    )
-                    return result
-
-                return wrapper
-
-            tracer.observe = observe
-            return tracer
+        tracer = _stub_tracer()
 
         examples = [
             {"example_id": "ex-1", "data": {"input": "q1"}},
@@ -990,10 +1035,7 @@ class TestRunAgentLoop:
             seen.append(input)
             return input
 
-        with patch(
-            "judgeval.trace.offline_tracer.OfflineTracer.create",
-            side_effect=fake_create,
-        ):
+        with _patched_offline_tracer(tracer):
             traces = runner.run_agent(agent, examples)
 
         assert seen == ["q1", "q2"]
@@ -1007,10 +1049,8 @@ class TestRunAgentLoop:
         client.base_url = "http://localhost"
 
         tracer = MagicMock()
-
-        def fake_create(**kwargs):
-            tracer.observe = lambda func, span_type=None: func
-            return tracer
+        tracer.observe = lambda func, span_type=None: func
+        tracer._get_current_trace_and_span_id = lambda: None
 
         def agent(input):
             if input == "q1":
@@ -1022,13 +1062,186 @@ class TestRunAgentLoop:
             {"example_id": "ex-2", "data": {"input": "q2"}},
         ]
 
-        with patch(
-            "judgeval.trace.offline_tracer.OfflineTracer.create",
-            side_effect=fake_create,
-        ):
+        with _patched_offline_tracer(tracer):
             traces = runner.run_agent(agent, examples)
 
         assert traces == {}
+
+    def test_run_agent_concurrent_traces_map_to_their_examples(self):
+        runner, client = _make_runner()
+        client.api_key = "key"
+        client.organization_id = "org"
+        client.base_url = "http://localhost"
+
+        tracer = _stub_tracer()
+
+        seen: dict = {}
+        lock = threading.Lock()
+
+        def agent(input):
+            with lock:
+                seen[input] = tracer._current_var.get()
+            return input
+
+        examples = [
+            {"example_id": f"ex-{i}", "data": {"input": f"q{i}"}} for i in range(8)
+        ]
+
+        with _patched_offline_tracer(tracer):
+            traces = runner.run_agent(agent, examples, concurrency=4)
+
+        assert traces == {f"ex-{i}": seen[f"q{i}"] for i in range(8)}
+        assert len(set(traces.values())) == 8
+
+    def test_run_agent_runs_examples_concurrently(self):
+        runner, client = _make_runner()
+        client.api_key = "key"
+        client.organization_id = "org"
+        client.base_url = "http://localhost"
+
+        tracer = _stub_tracer()
+
+        # Only releases if all 4 calls are in flight at once.
+        barrier = threading.Barrier(4)
+        done = []
+
+        def agent(input):
+            barrier.wait(timeout=10)
+            done.append(input)
+            return input
+
+        examples = [
+            {"example_id": f"ex-{i}", "data": {"input": f"q{i}"}} for i in range(4)
+        ]
+
+        with _patched_offline_tracer(tracer):
+            runner.run_agent(agent, examples, concurrency=4)
+
+        assert len(done) == 4
+
+    def test_run_agent_async_agent_concurrent(self):
+        runner, client = _make_runner()
+        client.api_key = "key"
+        client.organization_id = "org"
+        client.base_url = "http://localhost"
+
+        tracer = _stub_tracer()
+
+        seen: dict = {}
+        lock = threading.Lock()
+
+        async def agent(input):
+            with lock:
+                seen[input] = tracer._current_var.get()
+            return input
+
+        examples = [
+            {"example_id": f"ex-{i}", "data": {"input": f"q{i}"}} for i in range(4)
+        ]
+
+        with _patched_offline_tracer(tracer):
+            traces = runner.run_agent(agent, examples, concurrency=2)
+
+        assert traces == {f"ex-{i}": seen[f"q{i}"] for i in range(4)}
+
+    def test_run_agent_concurrency_must_be_positive(self):
+        runner, _ = _make_runner()
+        with pytest.raises(ValueError, match="concurrency"):
+            runner.run_agent(lambda input: input, [], concurrency=0)
+
+    def test_run_agent_field_mismatch_raises_before_any_agent_call(self):
+        runner, client = _make_runner()
+        client.api_key = "key"
+        client.organization_id = "org"
+        client.base_url = "http://localhost"
+
+        tracer = _stub_tracer()
+        calls = []
+
+        def agent(input):
+            calls.append(input)
+            return input
+
+        examples = [
+            {"example_id": "ex-1", "data": {"input": "q1"}},
+            {"example_id": "ex-2", "data": {"other": "q2"}},
+        ]
+
+        with _patched_offline_tracer(tracer):
+            with pytest.raises(TypeError, match="requires example field"):
+                runner.run_agent(agent, examples, concurrency=2)
+
+        assert calls == []
+
+    def test_run_agent_generator_agent_records_no_traces(self):
+        runner, client = _make_runner()
+        client.api_key = "key"
+        client.organization_id = "org"
+        client.base_url = "http://localhost"
+
+        tracer = _stub_tracer()
+
+        def agent(input):
+            yield input
+
+        with _patched_offline_tracer(tracer):
+            traces = runner.run_agent(
+                agent, [{"example_id": "ex-1", "data": {"input": "q1"}}]
+            )
+
+        assert traces == {}
+
+    def test_run_agent_real_tracer_concurrent_end_to_end(self):
+        """Exercise the real OfflineTracer / observe / context propagation
+        (only project resolution and span export are stubbed)."""
+        from judgeval.trace.base_tracer import BaseTracer
+
+        runner, client = _make_runner()
+        client.api_key = "key"
+        client.organization_id = "org"
+        client.base_url = "http://localhost:9999"
+
+        seen = {}
+        lock = threading.Lock()
+        barrier = threading.Barrier(3)
+        exported = []
+
+        def agent(input):
+            barrier.wait(timeout=10)
+            ids = BaseTracer._get_current_trace_and_span_id()
+            with lock:
+                seen[input] = ids[0] if ids else None
+            return f"answer:{input}"
+
+        examples = [
+            {"example_id": f"ex-{i}", "data": {"input": f"q{i}"}} for i in range(6)
+        ]
+
+        def fake_export(spans):
+            from opentelemetry.sdk.trace.export import SpanExportResult
+
+            exported.extend(spans)
+            return SpanExportResult.SUCCESS
+
+        with (
+            patch(
+                "judgeval.trace.offline_tracer.resolve_project_id",
+                return_value="p1",
+            ),
+            patch(
+                "judgeval.trace.exporters.judgment_span_exporter."
+                "JudgmentSpanExporter.export",
+                side_effect=fake_export,
+            ),
+        ):
+            traces = runner.run_agent(agent, examples, concurrency=3)
+
+        assert len(traces) == 6
+        assert len(set(traces.values())) == 6
+        for i in range(6):
+            assert traces[f"ex-{i}"] == seen[f"q{i}"]
+            assert len(traces[f"ex-{i}"]) == 32
+        assert {s.name for s in exported if s.parent is None} == {"agent"}
 
     def test_run_agent_restores_previous_active_tracer(self):
         from judgeval.trace.judgment_tracer_provider import JudgmentTracerProvider
@@ -1091,10 +1304,7 @@ class TestRunAgentLoop:
         def agent(question):
             return question
 
-        with patch(
-            "judgeval.trace.offline_tracer.OfflineTracer.create",
-            return_value=tracer,
-        ):
+        with _patched_offline_tracer(tracer):
             with pytest.raises(TypeError, match="requires example field"):
                 runner.run_agent(
                     agent, [{"example_id": "ex-1", "data": {"input": "q1"}}]


### PR DESCRIPTION
## Summary

Fixes [JUD-9600](https://linear.app/judgment/issue/JUD-9600/add-concurrency-for-offline-agent-test-execution): offline agent tests executed `agent_function` strictly sequentially, so wall-clock time scaled linearly with agent latency (reported by Melius).

- Adds `concurrency: int = 1` to `client.offline_tests.run()`, threaded through `OfflineTestRunner.run()` into `run_agent()`.
- `concurrency > 1`: agent calls run on a `ThreadPoolExecutor`, each inside `contextvars.copy_context()` — required because the active tracer lives in a ContextVar and worker threads start with an empty context.
- `concurrency == 1` (default): unchanged behavior — sequential, on the calling thread, so thread-affine agents (sqlite handles, signal timeouts) keep working.

## Key design change: example→trace correlation

The old loop correlated traces to examples by slicing the shared `captured` list (`captured[before:]`) — order-dependent and wrong under concurrency. Replaced with in-call capture: a `functools.wraps` probe records the root span's trace id from inside the observed call. Guards:

- records nothing when the offline tracer failed to activate (e.g. `run()` nested inside a live root span) — prevents attaching a foreign live trace id to every example
- records nothing for generator entrypoints, whose observed span never ends/exports (parity with old behavior)

## Hardening (from self-review)

- Fail fast: all example kwargs are built before any agent call, so a field mismatch raises with zero agent cost
- Interrupt-safe: pool shuts down with `cancel_futures=True`, so Ctrl-C/errors drop queued examples instead of draining the dataset
- `concurrency` validated on no-agent paths too

## Testing

- 9 `run_agent` unit tests: correlation correctness under concurrency=4, `threading.Barrier(4)` parallelism proof, async agents, fail-fast, generator parity, validation
- 1 end-to-end test with the **real** `OfflineTracer`/`observe`/context propagation (only project resolution + span export stubbed)
- Full suite: 646 passed; ruff + mypy clean

## Out of scope

TypeScript SDK has the same sequential loop (separate repo — needs a linked sub-issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)