### PR TITLE
feat(offline_tests): add concurrency for offline agent test execution (JUD-9600)

### DIFF
--- a/src/judgeval/offline_tests/offline_test_runner.py
+++ b/src/judgeval/offline_tests/offline_test_runner.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import inspect
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict, cast
 
 import orjson
@@ -413,37 +415,59 @@ class OfflineTestRunner:
         examples: List[Dict[str, Any]],
         progress: Optional[Progress] = None,
         field_mapping: Optional[Dict[str, str]] = None,
+        concurrency: int = 1,
     ) -> Dict[str, str]:
         """Call the agent entrypoint once per dataset example.
 
         Each call is wrapped in the `OfflineTracer` machinery so it
         produces a dedicated offline trace; the resulting trace IDs are
-        returned keyed by example ID. Entrypoint/example field mismatches
-        raise immediately; runtime errors inside the agent are recorded on
-        the trace and logged, and the loop continues. The previously
-        active tracer (if any) is restored once the loop finishes, so
-        subsequent `@observe` spans do not route to the offline endpoint.
+        returned keyed by example ID. Up to ``concurrency`` examples run
+        at a time (on worker threads); the default of 1 runs them
+        sequentially on the calling thread. Each example id rides on the
+        OTel context, so the offline span processor pairs it with the root
+        span it starts regardless of completion order. Entrypoint/example
+        field mismatches raise immediately; runtime errors inside the agent
+        are recorded on the trace and logged, and the remaining examples
+        still run. The previously active tracer (if any) is restored once
+        the loop finishes, so subsequent `@observe` spans do not route to
+        the offline endpoint.
 
         Before returning, the offline tracer is force-flushed and its
         provider shut down, so every agent trace is exported by the time
         the test run is created with these trace IDs attached.
         """
+        from opentelemetry import context as context_api
+
         from judgeval.trace.judgment_tracer_provider import JudgmentTracerProvider
         from judgeval.trace.offline_tracer import OfflineTracer
+        from judgeval.trace.processors.offline_judgment_span_processor import (
+            OFFLINE_EXAMPLE_ID_KEY,
+        )
+
+        if concurrency < 1:
+            raise ValueError(f"concurrency must be >= 1, got {concurrency}")
 
         proxy = JudgmentTracerProvider.get_instance()
         previous_tracer = proxy.get_active_tracer()
 
-        captured: List[Example] = []
         tracer = OfflineTracer.create(
             project_name=self._project_name,
             api_key=self._client.api_key,
             organization_id=self._client.organization_id,
             api_url=self._client.base_url,
             set_active=True,
-            dataset=captured,
+            dataset=[],
         )
+        processor = tracer.get_span_processor()
         try:
+            if proxy.get_active_tracer() is not tracer:
+                raise RuntimeError(
+                    "Offline tracer could not be activated because another tracer "
+                    "has a recording root span; agent traces cannot be attributed "
+                    "to this test run. Run offline tests outside of any active "
+                    "observed span."
+                )
+
             wrapped = tracer.observe(agent_function, span_type="agent")
             is_async = inspect.iscoroutinefunction(agent_function)
 
@@ -453,13 +477,16 @@ class OfflineTestRunner:
                     f"Running agent over {len(examples)} example(s)...", total=None
                 )
 
-            agent_traces: Dict[str, str] = {}
-            for index, example in enumerate(examples):
+            def invoke(example: Dict[str, Any]) -> None:
                 example_id = example.get("example_id") or ""
                 data = example.get("data") or {}
                 kwargs = build_agent_kwargs(agent_function, data, field_mapping)
 
-                before = len(captured)
+                token = proxy.attach_context(
+                    context_api.set_value(
+                        OFFLINE_EXAMPLE_ID_KEY, example_id, proxy.get_current_context()
+                    )
+                )
                 try:
                     if is_async:
                         asyncio.run(wrapped(**kwargs))
@@ -469,25 +496,38 @@ class OfflineTestRunner:
                     judgeval_logger.error(
                         f"Agent entrypoint raised for example {example_id}: {exc}"
                     )
+                finally:
+                    proxy.detach_context(token)
 
-                for produced in captured[before:]:
-                    offline_trace_id = produced._properties.get("offline_trace_id")
-                    if example_id and offline_trace_id:
-                        agent_traces[example_id] = offline_trace_id
-                        break
-
+            def advance(completed: int) -> None:
                 if progress is not None and task is not None:
                     progress.update(
                         task,
-                        description=f"Running agent... ({index + 1}/{len(examples)})",
+                        description=f"Running agent... ({completed}/{len(examples)})",
                     )
+
+            if concurrency == 1:
+                for index, example in enumerate(examples, 1):
+                    invoke(example)
+                    advance(index)
+            else:
+                # copy_context() carries the active tracer (a ContextVar) into
+                # the worker threads; each call then attaches its own example id.
+                with ThreadPoolExecutor(max_workers=concurrency) as pool:
+                    futures = [
+                        pool.submit(contextvars.copy_context().run, invoke, example)
+                        for example in examples
+                    ]
+                    for index, future in enumerate(as_completed(futures), 1):
+                        future.result()
+                        advance(index)
         finally:
             tracer.force_flush()
             proxy.restore_active(previous_tracer)
             proxy.deregister(tracer)
             tracer._tracer_provider.shutdown()
 
-        return agent_traces
+        return dict(processor.example_trace_ids)
 
     def wait_for_completion(
         self,
@@ -757,19 +797,23 @@ class OfflineTestRunner:
         timeout_seconds: int = 600,
         run_name: Optional[str] = None,
         field_mapping: Optional[Dict[str, str]] = None,
+        concurrency: int = 1,
     ) -> OfflineTestResult:
         """Execute the full offline-test lifecycle for a test config.
 
         When ``agent_function`` is omitted, no agent is invoked: the judges
         score each example's existing trace (the dataset's trace-typed
         column / ``offline_trace_id``). When provided, the agent is run once
-        per example first and the judges score the resulting agent trace.
+        per example first (up to ``concurrency`` examples at a time) and the
+        judges score the resulting agent trace.
         """
         if assert_test and pass_condition_fn is None:
             raise ValueError(
                 "assert_test=True requires a pass_condition_fn to decide "
                 "whether each row passes."
             )
+        if concurrency < 1:
+            raise ValueError(f"concurrency must be >= 1, got {concurrency}")
 
         console = Console()
         console.print("\n[bold cyan]Starting Offline Test[/bold cyan]")
@@ -803,7 +847,7 @@ class OfflineTestRunner:
             agent_traces: Dict[str, str] = {}
             if agent_function is not None and examples:
                 agent_traces = self.run_agent(
-                    agent_function, examples, progress, field_mapping
+                    agent_function, examples, progress, field_mapping, concurrency
                 )
 
             prepared = self.create_test_run(

--- a/src/judgeval/offline_tests/offline_tests_factory.py
+++ b/src/judgeval/offline_tests/offline_tests_factory.py
@@ -227,6 +227,7 @@ class OfflineTestsFactory:
         timeout_seconds: int = 600,
         run_name: Optional[str] = None,
         field_mapping: Optional[Dict[str, str]] = None,
+        concurrency: int = 1,
     ) -> Optional[OfflineTestResult]:
         """Run an offline test for a test config.
 
@@ -279,6 +280,11 @@ class OfflineTestsFactory:
                 field ``question``). Unmapped parameters fall back to the field
                 of the same name. Example fields the agent does not declare are
                 ignored.
+            concurrency: Maximum number of examples the agent runs over at a
+                time. Defaults to 1 (sequential, on the calling thread). Above
+                1, calls run on worker threads; an async agent runs each
+                example under its own event loop. Only affects the agent
+                execution loop; judge scoring happens server-side.
 
         Returns:
             An `OfflineTestResult`, or `None` if the project is not
@@ -286,8 +292,8 @@ class OfflineTestsFactory:
 
         Raises:
             ValueError: If `assert_test` is set without `pass_condition_fn`,
-                or if `dataset_version` does not match any version of the
-                config's dataset.
+                if `dataset_version` does not match any version of the
+                config's dataset, or if `concurrency` is less than 1.
             TypeError: If the agent entrypoint cannot accept an example's
                 fields.
             JudgmentValidationError: If the server rejects the run (e.g.
@@ -321,4 +327,5 @@ class OfflineTestsFactory:
             timeout_seconds=timeout_seconds,
             run_name=run_name,
             field_mapping=field_mapping,
+            concurrency=concurrency,
         )

--- a/src/judgeval/trace/processors/offline_judgment_span_processor.py
+++ b/src/judgeval/trace/processors/offline_judgment_span_processor.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import threading
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry import context as context_api
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import ReadableSpan, Span
 from opentelemetry.sdk.trace.export import SpanExporter
 
 from judgeval.trace.processors.judgment_span_processor import JudgmentSpanProcessor
@@ -11,6 +13,14 @@ from judgeval.trace.processors.judgment_span_processor import JudgmentSpanProces
 if TYPE_CHECKING:
     from judgeval.data.example import Example
     from judgeval.trace.base_tracer import BaseTracer
+
+
+OFFLINE_EXAMPLE_ID_KEY = context_api.create_key("judgment.offline_example_id")
+"""Context key naming the dataset example a root span belongs to.
+
+Set it on the context before starting the span and the processor records
+the ``example_id -> trace_id`` pairing in ``example_trace_ids``.
+"""
 
 
 class OfflineJudgmentSpanProcessor(JudgmentSpanProcessor):
@@ -28,6 +38,7 @@ class OfflineJudgmentSpanProcessor(JudgmentSpanProcessor):
         "_example_fields",
         "_dataset_lock",
         "_seen_trace_ids",
+        "example_trace_ids",
     )
 
     def __init__(
@@ -44,6 +55,9 @@ class OfflineJudgmentSpanProcessor(JudgmentSpanProcessor):
         self._example_fields: Dict[str, Any] = dict(example_fields or {})
         self._dataset_lock = threading.Lock()
         self._seen_trace_ids: set[str] = set()
+        # example_id -> trace_id of the first root span started under that
+        # example's context (see OFFLINE_EXAMPLE_ID_KEY).
+        self.example_trace_ids: Dict[str, str] = {}
 
     def _maybe_create_example(self, span: ReadableSpan) -> None:
         if span.parent is not None or not span.context:
@@ -65,6 +79,20 @@ class OfflineJudgmentSpanProcessor(JudgmentSpanProcessor):
 
         with self._dataset_lock:
             self._dataset.append(example)
+
+    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
+        example_id = context_api.get_value(OFFLINE_EXAMPLE_ID_KEY, parent_context)
+        if (
+            isinstance(example_id, str)
+            and example_id
+            and span.parent is None
+            and span.context
+        ):
+            with self._dataset_lock:
+                self.example_trace_ids.setdefault(
+                    example_id, format(span.context.trace_id, "032x")
+                )
+        super().on_start(span, parent_context)
 
     def on_end(self, span: ReadableSpan) -> None:
         try:

--- a/src/tests/offline_tests/test_offline_test_runner.py
+++ b/src/tests/offline_tests/test_offline_test_runner.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 import json
+import random
+import threading
+import time
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
+from opentelemetry.sdk.trace.export import SpanExportResult
 
 from judgeval.data.example import Example
 from judgeval.data.scorer_data import ScorerData
@@ -18,6 +24,9 @@ from judgeval.offline_tests.offline_test_runner import (
     normalize_judge_versions,
 )
 from judgeval.offline_tests.types import OfflineTestResult, TestConfig
+from judgeval.trace.exporters.judgment_span_exporter import JudgmentSpanExporter
+from judgeval.trace.judgment_tracer_provider import JudgmentTracerProvider
+from judgeval.trace.offline_tracer import OfflineTracer
 
 CONFIG = TestConfig(id="cfg-1", name="nightly", dataset_id="d1")
 
@@ -127,6 +136,43 @@ def _make_runner():
         client=client, project_id="proj-1", project_name="test-project"
     )
     return runner, client
+
+
+def _agent_runner():
+    runner, client = _make_runner()
+    client.api_key = "key"
+    client.organization_id = "org"
+    client.base_url = "http://localhost"
+    return runner
+
+
+def _examples(count):
+    return [{"example_id": f"ex-{i}", "data": {"input": f"q{i}"}} for i in range(count)]
+
+
+def _trace_id():
+    span = JudgmentTracerProvider.get_instance().get_current_span()
+    return format(span.get_span_context().trace_id, "032x")
+
+
+@contextmanager
+def _offline_spans():
+    """Run with a real, network-free OfflineTracer.
+
+    Project lookup and OTLP export are stubbed; exported spans land in the
+    yielded list.
+    """
+    spans = []
+
+    def fake_export(self, batch):
+        spans.extend(batch)
+        return SpanExportResult.SUCCESS
+
+    with (
+        patch("judgeval.trace.offline_tracer.resolve_project_id", return_value="p1"),
+        patch.object(JudgmentSpanExporter, "export", fake_export),
+    ):
+        yield spans
 
 
 def _stub_raw_request(client, items_pages=None):
@@ -816,7 +862,9 @@ class TestRunOrchestration:
             calls.append(input)
             return f"answer to {input}"
 
-        def fake_run_agent(agent_function, examples, progress=None, field_mapping=None):
+        def fake_run_agent(
+            agent_function, examples, progress=None, field_mapping=None, concurrency=1
+        ):
             # examples come from the dataset fetch, not the prepare response
             assert [e["example_id"] for e in examples] == ["ex-1"]
             for example in examples:
@@ -837,7 +885,9 @@ class TestRunOrchestration:
         runner, client = _make_runner()
         _stub_lifecycle(client)
 
-        def fake_run_agent(agent_function, examples, progress=None, field_mapping=None):
+        def fake_run_agent(
+            agent_function, examples, progress=None, field_mapping=None, concurrency=1
+        ):
             return {"ex-1": "trace-abc"}
 
         with patch.object(OfflineTestRunner, "run_agent", side_effect=fake_run_agent):
@@ -861,7 +911,9 @@ class TestRunOrchestration:
         _stub_lifecycle(client)
         order = []
 
-        def fake_run_agent(agent_function, examples, progress=None, field_mapping=None):
+        def fake_run_agent(
+            agent_function, examples, progress=None, field_mapping=None, concurrency=1
+        ):
             order.append("agent")
             assert client.post_projects_test_runs.call_count == 0
             return {"ex-1": "trace-abc"}
@@ -911,38 +963,39 @@ class TestRunOrchestration:
         client.organization_id = "org"
         client.base_url = "http://localhost"
 
-        tracer = MagicMock()
+        shutdowns = []
+        real_create = OfflineTracer.create
 
-        def fake_create(**kwargs):
-            dataset = kwargs["dataset"]
-
-            def observe(func, span_type=None):
-                def wrapper(**call_kwargs):
-                    result = func(**call_kwargs)
-                    dataset.append(Example.create(offline_trace_id="trace-abc"))
-                    return result
-
-                return wrapper
-
-            tracer.observe = observe
+        def spy_create(**kwargs):
+            tracer = real_create(**kwargs)
+            original_shutdown = tracer._tracer_provider.shutdown
+            tracer._tracer_provider.shutdown = lambda: (
+                shutdowns.append(True),
+                original_shutdown(),
+            )
             return tracer
 
         def fake_post(**kwargs):
-            # by the time the run is created, the offline tracer has been
-            # flushed and its provider shut down
-            tracer.force_flush.assert_called_once()
-            tracer._tracer_provider.shutdown.assert_called_once()
+            # by the time the run is created, the offline tracer's provider
+            # has been shut down (which flushes its spans)
+            assert shutdowns == [True]
             return dict(PREPARED)
 
         client.post_projects_test_runs.side_effect = fake_post
 
-        with patch(
-            "judgeval.trace.offline_tracer.OfflineTracer.create",
-            side_effect=fake_create,
+        with (
+            _offline_spans() as spans,
+            patch(
+                "judgeval.trace.offline_tracer.OfflineTracer.create",
+                side_effect=spy_create,
+            ),
         ):
             outcome = runner.run(CONFIG, agent_function=lambda input: input)
 
-        assert outcome.agent_offline_trace_ids == {"ex-1": "trace-abc"}
+        root = next(span for span in spans if span.parent is None)
+        assert outcome.agent_offline_trace_ids == {
+            "ex-1": format(root.context.trace_id, "032x")
+        }
         client.post_projects_test_runs.assert_called_once()
 
     def test_timeout_raises(self):
@@ -953,121 +1006,139 @@ class TestRunOrchestration:
 
 
 class TestRunAgentLoop:
-    def test_run_agent_wraps_with_offline_tracer(self):
-        runner, client = _make_runner()
-        client.api_key = "key"
-        client.organization_id = "org"
-        client.base_url = "http://localhost"
-
-        tracer = MagicMock()
-        captured_examples = []
-
-        def fake_create(**kwargs):
-            captured_examples.append(kwargs["dataset"])
-            dataset = kwargs["dataset"]
-
-            def observe(func, span_type=None):
-                def wrapper(**call_kwargs):
-                    result = func(**call_kwargs)
-                    dataset.append(
-                        Example.create(offline_trace_id=f"trace-{len(dataset)}")
-                    )
-                    return result
-
-                return wrapper
-
-            tracer.observe = observe
-            return tracer
-
-        examples = [
-            {"example_id": "ex-1", "data": {"input": "q1"}},
-            {"example_id": "ex-2", "data": {"input": "q2"}},
-        ]
-
-        seen = []
+    def test_default_is_sequential_and_maps_each_example_to_its_trace(self):
+        runner = _agent_runner()
+        order, seen, in_flight, max_in_flight = [], {}, [0], [0]
 
         def agent(input):
-            seen.append(input)
+            in_flight[0] += 1
+            max_in_flight[0] = max(max_in_flight[0], in_flight[0])
+            order.append(input)
+            seen[input] = _trace_id()
+            time.sleep(0.005)
+            in_flight[0] -= 1
             return input
 
-        with patch(
-            "judgeval.trace.offline_tracer.OfflineTracer.create",
-            side_effect=fake_create,
-        ):
-            traces = runner.run_agent(agent, examples)
+        with _offline_spans() as spans:
+            traces = runner.run_agent(agent, _examples(3))
 
-        assert seen == ["q1", "q2"]
-        assert traces == {"ex-1": "trace-0", "ex-2": "trace-1"}
-        tracer.force_flush.assert_called_once()
+        assert order == ["q0", "q1", "q2"]
+        assert max_in_flight[0] == 1
+        assert traces == {f"ex-{i}": seen[f"q{i}"] for i in range(3)}
+        assert len([span for span in spans if span.parent is None]) == 3
 
-    def test_run_agent_continues_after_agent_error(self):
-        runner, client = _make_runner()
-        client.api_key = "key"
-        client.organization_id = "org"
-        client.base_url = "http://localhost"
+    def test_concurrent_calls_map_to_their_own_trace(self):
+        runner = _agent_runner()
+        seen = {}
 
-        tracer = MagicMock()
+        def agent(input):
+            seen[input] = _trace_id()
+            # Randomize completion order to stress correlation.
+            time.sleep(random.random() * 0.02)
+            return input
 
-        def fake_create(**kwargs):
-            tracer.observe = lambda func, span_type=None: func
-            return tracer
+        with _offline_spans():
+            traces = runner.run_agent(agent, _examples(8), concurrency=4)
+
+        assert traces == {f"ex-{i}": seen[f"q{i}"] for i in range(8)}
+        assert len(set(traces.values())) == 8
+
+    def test_runs_examples_concurrently(self):
+        runner = _agent_runner()
+        # Only opens once all 4 calls are in flight; raises BrokenBarrierError
+        # (timeout) if execution regresses to sequential.
+        barrier = threading.Barrier(4, timeout=5)
+
+        def agent(input):
+            barrier.wait()
+            return input
+
+        with _offline_spans():
+            traces = runner.run_agent(agent, _examples(4), concurrency=4)
+
+        assert len(traces) == 4
+
+    def test_async_agent_under_concurrency(self):
+        runner = _agent_runner()
+
+        async def agent(input):
+            await asyncio.sleep(0.01)
+            return input
+
+        with _offline_spans():
+            traces = runner.run_agent(agent, _examples(4), concurrency=2)
+
+        assert sorted(traces) == ["ex-0", "ex-1", "ex-2", "ex-3"]
+        assert len(set(traces.values())) == 4
+
+    def test_agent_error_does_not_abort_remaining_examples(self):
+        runner = _agent_runner()
 
         def agent(input):
             if input == "q1":
                 raise RuntimeError("boom")
             return input
 
-        examples = [
-            {"example_id": "ex-1", "data": {"input": "q1"}},
-            {"example_id": "ex-2", "data": {"input": "q2"}},
-        ]
+        with _offline_spans():
+            traces = runner.run_agent(agent, _examples(3), concurrency=2)
 
-        with patch(
-            "judgeval.trace.offline_tracer.OfflineTracer.create",
-            side_effect=fake_create,
-        ):
-            traces = runner.run_agent(agent, examples)
+        # The failing example still produced a trace (error recorded on it).
+        assert sorted(traces) == ["ex-0", "ex-1", "ex-2"]
 
+    def test_records_input_under_agent_param_name(self):
+        runner = _agent_runner()
+
+        with _offline_spans() as spans:
+            traces = runner.run_agent(
+                lambda question: question,
+                [{"example_id": "ex-1", "data": {"question": "q1"}}],
+            )
+
+        root = next(span for span in spans if span.parent is None)
+        assert json.loads(root.attributes["judgment.input"]) == {"question": "q1"}
+        assert traces == {"ex-1": format(root.context.trace_id, "032x")}
+
+    def test_skips_examples_without_id(self):
+        runner = _agent_runner()
+        with _offline_spans():
+            traces = runner.run_agent(
+                lambda input: input, [{"example_id": "", "data": {"input": "q"}}]
+            )
         assert traces == {}
 
-    def test_run_agent_restores_previous_active_tracer(self):
-        from judgeval.trace.judgment_tracer_provider import JudgmentTracerProvider
+    def test_rejects_concurrency_below_one(self):
+        runner = _agent_runner()
+        with pytest.raises(ValueError, match="concurrency"):
+            runner.run_agent(lambda input: input, [], concurrency=0)
 
-        runner, client = _make_runner()
-        client.api_key = "key"
-        client.organization_id = "org"
-        client.base_url = "http://localhost"
-
+    def test_restores_previous_tracer_and_releases_offline_tracer(self):
+        runner = _agent_runner()
         proxy = JudgmentTracerProvider.get_instance()
         original = proxy.get_active_tracer()
         previous = MagicMock()
         proxy.set_active(previous)
+        created = []
+        real_create = OfflineTracer.create
 
-        tracer = MagicMock()
-
-        def fake_create(**kwargs):
-            assert kwargs["set_active"] is True
-            proxy.set_active(tracer)
-            tracer.observe = lambda func, span_type=None: func
+        def spy_create(**kwargs):
+            tracer = real_create(**kwargs)
+            created.append(tracer)
             return tracer
 
         try:
-            with patch(
-                "judgeval.trace.offline_tracer.OfflineTracer.create",
-                side_effect=fake_create,
+            with (
+                _offline_spans(),
+                patch(
+                    "judgeval.trace.offline_tracer.OfflineTracer.create",
+                    side_effect=spy_create,
+                ),
             ):
-                runner.run_agent(
-                    lambda input: input,
-                    [{"example_id": "ex-1", "data": {"input": "q1"}}],
-                )
+                runner.run_agent(lambda input: input, _examples(1))
             assert proxy.get_active_tracer() is previous
-            tracer._tracer_provider.shutdown.assert_called_once()
+            assert created[0] not in proxy._judgment_tracers
 
             # restored even when the agent loop raises
-            with patch(
-                "judgeval.trace.offline_tracer.OfflineTracer.create",
-                side_effect=fake_create,
-            ):
+            with _offline_spans():
                 with pytest.raises(TypeError, match="requires example field"):
                     runner.run_agent(
                         lambda input: input,
@@ -1076,25 +1147,35 @@ class TestRunAgentLoop:
             assert proxy.get_active_tracer() is previous
         finally:
             proxy.deregister(previous)
-            proxy.deregister(tracer)
             proxy.restore_active(original)
 
-    def test_run_agent_signature_mismatch_raises(self):
-        runner, client = _make_runner()
-        client.api_key = "key"
-        client.organization_id = "org"
-        client.base_url = "http://localhost"
+    def test_refused_activation_raises_and_cleans_up(self):
+        runner = _agent_runner()
+        proxy = JudgmentTracerProvider.get_instance()
+        original = proxy.get_active_tracer()
+        calls = []
 
-        tracer = MagicMock()
-        tracer.observe = lambda func, span_type=None: func
+        with (
+            _offline_spans(),
+            patch.object(JudgmentTracerProvider, "set_active", return_value=False),
+        ):
+            registered_before = len(proxy._judgment_tracers)
+            with pytest.raises(RuntimeError, match="could not be activated"):
+                runner.run_agent(
+                    lambda input: calls.append(input), _examples(2), concurrency=2
+                )
+
+        assert calls == []
+        assert proxy.get_active_tracer() is original
+        assert len(proxy._judgment_tracers) == registered_before
+
+    def test_signature_mismatch_raises(self):
+        runner = _agent_runner()
 
         def agent(question):
             return question
 
-        with patch(
-            "judgeval.trace.offline_tracer.OfflineTracer.create",
-            return_value=tracer,
-        ):
+        with _offline_spans():
             with pytest.raises(TypeError, match="requires example field"):
                 runner.run_agent(
                     agent, [{"example_id": "ex-1", "data": {"input": "q1"}}]

--- a/src/tests/offline_tests/test_offline_tests_factory.py
+++ b/src/tests/offline_tests/test_offline_tests_factory.py
@@ -135,6 +135,13 @@ class TestRuns:
         assert isinstance(config_arg, TestConfig)
         assert config_arg.id == "cfg-1"
 
+    def test_run_passes_concurrency_through(self):
+        factory, _ = _make_factory()
+        config = TestConfig(id="cfg-1", name="nightly", dataset_id="d1")
+        with patch.object(OfflineTestRunner, "run", return_value=None) as run_mock:
+            factory.run(test_config=config, concurrency=3)
+        assert run_mock.call_args.kwargs["concurrency"] == 3
+
     def test_run_accepts_test_config_object(self):
         factory, client = _make_factory()
         config = TestConfig(id="cfg-1", name="nightly", dataset_id="d1")


### PR DESCRIPTION
## 📝 Summary

Fixes [JUD-9600](https://linear.app/judgment/issue/JUD-9600/add-concurrency-for-offline-agent-test-execution). Parity with the TypeScript change in [judgeval-js#82](https://github.com/JudgmentLabs/judgeval-js/pull/82) (merged). Supersedes #780, which correlated traces with a probe wrapper around the agent; this follows the reviewer direction there to do it in the tracer via the OTel context instead.

- [x] 1. `concurrency: int = 1` on `client.offline_tests.run()`, threaded through `OfflineTestRunner.run()` into `run_agent()`. Above 1, agent calls run on a `ThreadPoolExecutor`, each inside `contextvars.copy_context()` so the active tracer (a ContextVar) follows into the worker threads. The default of 1 is unchanged: sequential, on the calling thread.
- [x] 2. Example→trace correlation moves into the tracer. `run_agent` attaches `OFFLINE_EXAMPLE_ID_KEY` to the context per call (via the provider's `attach_context`), and `OfflineJudgmentSpanProcessor.on_start` records `example_id -> trace_id` for root spans started under that context (`example_trace_ids`, first root span wins). The agent function is observed directly with `tracer.observe(agent_function, span_type="agent")`, so `judgment.input` keeps the customer's own parameter names. The old `captured[before:]` ordering trick is gone.
- [x] 3. If the offline tracer can't be activated (run nested inside a live root span), `run_agent` raises instead of silently producing a run with nothing to score. Cleanup (flush, `restore_active`, `deregister`, provider shutdown) runs on that path too.
- [x] 4. Tests: the `run_agent` suite now runs a real network-free `OfflineTracer` (project lookup + OTLP export stubbed) and covers sequential default and ordering, correlation under concurrency with randomized completion order, actual parallelism (barrier), async agents under concurrency, error isolation, `judgment.input` under the agent's param name, empty example ids, refused activation, and previous-tracer restore / tracer release.

### E2E (Internal Customer Support Agent, dataset "post-agent improvement", 10 examples)

Ran `client.offline_tests.run(..., concurrency=4)` and `concurrency=1` against the live backend with an agent that records which trace it ran under per input. Both: 10/10 examples mapped to the exact trace the agent saw, 0 mismatches, max in-flight 4 vs 1, no tracer left registered, active tracer cleared afterwards. Server-side `agent_offline_trace_id` per example matches what the SDK sent.

- concurrency=4: https://app.judgmentlabs.ai/org/df8607d9-1467-4e5e-b33d-c23e52a161fc/project/fcc6f904-c61b-456c-9817-f568e690f837/tests/0a974e7a-adb8-445f-9f22-4a516d37ca69/runs/df202eea-902d-464a-9b0f-ab8e5435aa56
- concurrency=1: https://app.judgmentlabs.ai/org/df8607d9-1467-4e5e-b33d-c23e52a161fc/project/fcc6f904-c61b-456c-9817-f568e690f837/tests/0a974e7a-adb8-445f-9f22-4a516d37ca69/runs/5d2a507f-4d5b-4bd7-98ee-afdd4560fc6c

## ✅ Checklist

- [ ] Docs updated ([if necessary](https://github.com/JudgmentLabs/docs)) — `concurrency` param on `offline_tests.run()` should be added to the offline tests docs
- [ ] Changelogs are updated ([if necessary](https://github.com/JudgmentLabs/docs/tree/main/content/docs/changelog/%28weekly%29))

🤖 Generated with [Claude Code](https://claude.com/claude-code)
