### PR TITLE
docs: add docstring to update_file and guard CLI with __main__

### DIFF
--- a/update_version.py
+++ b/update_version.py
@@ -1,14 +1,21 @@
 import sys
 
-if len(sys.argv) != 2:
-    print("Usage: python set_version.py <new_version>")
-    sys.exit(1)
-
-new_version = sys.argv[1]
 version_placeholder = "0.0.0"
 
 
 def update_file(file_path, placeholder, new_val):
+    """Replace the first occurrence of ``placeholder`` with ``new_val`` in ``file_path``.
+
+    Reads the file at ``file_path``, verifies that ``placeholder`` is present,
+    substitutes the first occurrence with ``new_val``, and writes the result back.
+    Exits the process with a non-zero status code on I/O errors or when the
+    placeholder is not found.
+
+    Args:
+        file_path (str): Path to the file that should be updated.
+        placeholder (str): The string token to search for and replace.
+        new_val (str): The value that replaces the first occurrence of ``placeholder``.\
+    """
     try:
         with open(file_path, "r") as f:
             content = f.read()
@@ -30,6 +37,12 @@ def update_file(file_path, placeholder, new_val):
         sys.exit(1)
 
 
-files_to_update = ["pyproject.toml", "src/judgeval/version.py"]
-for file in files_to_update:
-    update_file(file, version_placeholder, new_version)
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python set_version.py <new_version>")
+        sys.exit(1)
+
+    new_version = sys.argv[1]
+    files_to_update = ["pyproject.toml", "src/judgeval/version.py"]
+    for file in files_to_update:
+        update_file(file, version_placeholder, new_version)


### PR DESCRIPTION
Add a Google-style docstring to the `update_file()` function and wrap the top-level CLI invocation in an `if __name__ == "__main__":` guard.

## Changes

- **Docstring on `update_file()`** — documents parameters, expected behaviour, and exit conditions (missing before)
- **`__main__` guard** — the script previously called `sys.exit(1)` at module level when imported without arguments; wrapping the CLI code in `if __name__ == "__main__":` follows standard Python practice and makes the module importable safely

## Why

The original script executed immediately on import, causing it to crash with a usage error when any tool tried to import it as a module. The `__main__` guard is idiomatic Python for CLI scripts and has no effect on the script's runtime behaviour when called directly.

---
*Co-authored-by: Hermes Agent <hermes@nousresearch.com>*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval/pull/785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->