### PR TITLE
feat(trace): support explicit project ID initialization

### DIFF
--- a/src/judgeval/trace/tracer.py
+++ b/src/judgeval/trace/tracer.py
@@ -43,7 +43,7 @@ class Tracer(BaseTracer):
 
     Args:
         project_name: Your Judgment project name.
-        project_id: Resolved project ID (set automatically by `init`).
+        project_id: Project ID supplied to `init`, or resolved from `project_name`.
         api_key: Judgment API key.
         organization_id: Organization ID.
         api_url: Judgment API endpoint URL.
@@ -131,6 +131,8 @@ class Tracer(BaseTracer):
         sampler: Optional[Sampler] = None,
         span_limits: Optional[SpanLimits] = None,
         span_processors: Optional[Sequence[SpanProcessor]] = None,
+        *,
+        project_id: Optional[str] = None,
     ) -> Tracer:
         """Create and activate a new Tracer.
 
@@ -140,7 +142,10 @@ class Tracer(BaseTracer):
         missing, the tracer still works but spans won't be exported.
 
         Args:
-            project_name: Your Judgment project name. Required for span export.
+            project_name: Your Judgment project name. Used to resolve the project
+                ID when `project_id` is not supplied.
+            project_id: Judgment project ID. When provided, skips project name
+                resolution.
             api_key: Judgment API key. Defaults to `JUDGMENT_API_KEY` env var.
             organization_id: Organization ID. Defaults to `JUDGMENT_ORG_ID` env var.
             api_url: API endpoint URL. Defaults to `JUDGMENT_API_URL` env var.
@@ -164,6 +169,7 @@ class Tracer(BaseTracer):
                 project_name="search-assistant",
                 environment="production",
             )
+            tracer = Tracer.init(project_id="proj_456")
             ```
         """
         api_key = api_key or JUDGMENT_API_KEY
@@ -172,9 +178,9 @@ class Tracer(BaseTracer):
 
         enable_monitoring = True
 
-        if not project_name:
+        if not project_name and not project_id:
             judgeval_logger.warning(
-                "project_name not provided. Tracer will not export spans."
+                "project_name or project_id not provided. Tracer will not export spans."
             )
             enable_monitoring = False
 
@@ -197,21 +203,15 @@ class Tracer(BaseTracer):
             enable_monitoring = False
 
         client: Optional[JudgmentSyncClient] = None
-        project_id: Optional[str] = None
-        if (
-            enable_monitoring
-            and project_name
-            and api_key
-            and organization_id
-            and api_url
-        ):
+        if enable_monitoring and api_key and organization_id and api_url:
             client = JudgmentSyncClient(api_url, api_key, organization_id)
-            project_id = resolve_project_id(client, project_name)
-            if not project_id:
-                judgeval_logger.warning(
-                    f"Project '{project_name}' not found. Tracer will not export spans."
-                )
-                enable_monitoring = False
+            if not project_id and project_name:
+                project_id = resolve_project_id(client, project_name)
+                if not project_id:
+                    judgeval_logger.warning(
+                        f"Project '{project_name}' not found. Tracer will not export spans."
+                    )
+                    enable_monitoring = False
 
         resource_attrs = {
             "service.name": project_name or "unknown",

--- a/src/tests/trace/test_project_id_export.py
+++ b/src/tests/trace/test_project_id_export.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from judgeval.trace.tracer import Tracer
+
+
+def test_project_id_export_bypasses_resolution():
+    recorded: list[dict] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def _record(self):
+            length = int(self.headers.get("Content-Length") or 0)
+            body = self.rfile.read(length) if length else b""
+            recorded.append(
+                {
+                    "method": self.command,
+                    "path": self.path,
+                    "headers": {k.lower(): v for k, v in self.headers.items()},
+                    "body": body,
+                }
+            )
+            self.send_response(200)
+            self.end_headers()
+
+        def do_POST(self):
+            self._record()
+
+        def do_GET(self):
+            self._record()
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    t = None
+    try:
+        port = server.server_address[1]
+        t = Tracer.init(
+            project_id="pid-e2e",
+            api_key="dummy",
+            organization_id="dummy-org",
+            api_url=f"http://127.0.0.1:{port}",
+        )
+
+        @Tracer.observe()
+        def work():
+            return "ok"
+
+        work()
+        t._tracer_provider.force_flush()
+
+        otel = [
+            r
+            for r in recorded
+            if r["method"] == "POST" and r["path"].endswith("/otel/v1/traces")
+        ]
+        assert otel
+        for r in otel:
+            assert r["headers"].get("x-project-id") == "pid-e2e"
+            assert r["headers"].get("x-organization-id") == "dummy-org"
+            assert r["headers"].get("authorization") == "Bearer dummy"
+        assert not any("/projects/resolve" in r["path"] for r in recorded)
+    finally:
+        if t is not None:
+            t._tracer_provider.shutdown()
+        server.shutdown()
+        server.server_close()

--- a/src/tests/trace/test_tracer_init.py
+++ b/src/tests/trace/test_tracer_init.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import inspect
 from unittest.mock import patch
+
+import pytest
 
 from judgeval.trace.tracer import Tracer
 from judgeval.trace.offline_tracer import OfflineTracer
@@ -45,6 +48,39 @@ class TestTracerInitDisabled:
             )
         assert t._enable_monitoring is False
 
+    @pytest.mark.parametrize("project_id", ["", None])
+    def test_neither_identifier(self, project_id):
+        with patch("judgeval.trace.tracer.resolve_project_id") as resolve:
+            t = Tracer.init(
+                project_id=project_id,
+                api_key="k",
+                organization_id="o",
+                api_url="http://x",
+            )
+        assert t._enable_monitoring is False
+        assert not t.project_id
+        assert isinstance(t.get_span_exporter(), NoOpJudgmentSpanExporter)
+        resolve.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "missing,const",
+        [
+            ("api_key", "JUDGMENT_API_KEY"),
+            ("organization_id", "JUDGMENT_ORG_ID"),
+            ("api_url", "JUDGMENT_API_URL"),
+        ],
+    )
+    def test_project_id_missing_credential(self, missing, const):
+        kwargs = {"api_key": "k", "organization_id": "o", "api_url": "http://x"}
+        kwargs[missing] = None
+        with (
+            patch("judgeval.trace.tracer.resolve_project_id") as resolve,
+            patch(f"judgeval.trace.tracer.{const}", None),
+        ):
+            t = Tracer.init(project_id="pid", **kwargs)
+        assert t._enable_monitoring is False
+        resolve.assert_not_called()
+
 
 class TestTracerInitEnabled:
     def test_full_config(self):
@@ -60,6 +96,62 @@ class TestTracerInitEnabled:
         assert t.project_name == "proj"
         assert isinstance(t.get_span_exporter(), JudgmentSpanExporter)
         assert isinstance(t.get_span_processor(), JudgmentSpanProcessor)
+
+    def test_project_id_only(self):
+        with patch("judgeval.trace.tracer.resolve_project_id") as resolve:
+            t = Tracer.init(
+                project_id="supplied-pid",
+                api_key="k",
+                organization_id="o",
+                api_url="http://x",
+            )
+        assert t._enable_monitoring is True
+        assert t.project_id == "supplied-pid"
+        assert t.project_name is None
+        assert isinstance(t.get_span_exporter(), JudgmentSpanExporter)
+        resolve.assert_not_called()
+        assert t._tracer_provider.resource.attributes.get("service.name") == "unknown"
+
+    def test_project_id_wins_over_name(self):
+        with patch("judgeval.trace.tracer.resolve_project_id") as resolve:
+            t = Tracer.init(
+                project_name="proj",
+                project_id="supplied-pid",
+                api_key="k",
+                organization_id="o",
+                api_url="http://x",
+            )
+        assert t._enable_monitoring is True
+        assert t.project_id == "supplied-pid"
+        assert t.project_name == "proj"
+        resolve.assert_not_called()
+        assert t._tracer_provider.resource.attributes.get("service.name") == "proj"
+
+    @pytest.mark.parametrize("project_id", ["", None])
+    def test_empty_or_none_project_id_falls_back_to_name(self, project_id):
+        with patch(
+            "judgeval.trace.tracer.resolve_project_id", return_value="resolved"
+        ) as resolve:
+            t = Tracer.init(
+                project_name="proj",
+                project_id=project_id,
+                api_key="k",
+                organization_id="o",
+                api_url="http://x",
+            )
+        assert t._enable_monitoring is True
+        assert t.project_id == "resolved"
+        resolve.assert_called_once()
+        assert resolve.call_args.args[1] == "proj"
+
+    def test_positional_compatibility(self):
+        with patch("judgeval.trace.tracer.resolve_project_id", return_value="pid"):
+            t = Tracer.init("proj", "k", "o", "http://x", "staging")
+        assert t.environment == "staging"
+        assert (
+            inspect.signature(Tracer.init).parameters["project_id"].kind
+            is inspect.Parameter.KEYWORD_ONLY
+        )
 
     def test_endpoint_with_trailing_slash(self):
         with patch("judgeval.trace.tracer.resolve_project_id", return_value="p"):


### PR DESCRIPTION
## Summary
- Add keyword-only `project_id` to `Tracer.init` without changing existing positional parameters.
- Prefer a nonempty supplied ID over the project name and skip project resolution entirely; retain name-only fallback, credential gating and resource metadata.
- Add focused regression coverage and a local span-to-OTLP HTTP export test verifying the supplied project header and no resolution request.

## Verification
- Tracing suite: **184 passed, 1 skipped**.
- Full `src/tests` suite: **656 passed, 1 skipped**, with 182 warnings (datetime deprecation and intentional duplicate-archive fixture).
- Ruff check and format check: all three changed files pass.
- `git diff --check`: passes.
- New project-ID regressions also fail against the original initializer with the expected unsupported-keyword error.

The HTTP export test is **local E2E using dummy credentials**, not live Judgment-backend or Pydantic AI verification. No environment-variable support, offline-tracer changes, project renaming, or TypeScript changes are included. Freshly fetched judgeval-js main was inspected for inspiration; it still resolves by name, so this PR does not claim existing TS ID-initialization parity.

## Review workflow
Independent stable-diff review by Claude `claude-fable-5-1` at high effort: **approve, no blockers**.
Cursor `cursor-grok-4.6-xhigh-fast` authored the implementation under Claude `claude-fable-5-1` high preflight guidance. Hermes independently executed tests and inspected the diff. Cursor's test commands were blocked by permissions, so regression failure was verified retrospectively rather than claiming a completed test-first run.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval/pull/789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->